### PR TITLE
[CONTP-663] fix bug in unix endpoint parsing logic

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -27,18 +27,18 @@ func EnsureSocketAvailability(unixEndpoint string) (address string, err error) {
 		return "", errors.New("endpoint path can't be empty")
 	}
 
-	if scheme := strings.ToLower(parsedURL.Scheme); scheme != "unix" {
-		return "", fmt.Errorf("%q is not a unix endpoint", unixEndpoint)
-	}
-
-	if err := removeFile(address); err != nil && os.IsExist(err) {
-		return "", fmt.Errorf("could not remove unix socket %q: %v", address, err)
-	}
-
 	if len(parsedURL.Host) == 0 {
 		address = filepath.FromSlash(parsedURL.Path)
 	} else {
 		address = path.Join(parsedURL.Host, filepath.FromSlash(parsedURL.Path))
+	}
+
+	if scheme := strings.ToLower(parsedURL.Scheme); scheme != "unix" {
+		return "", fmt.Errorf("%q is not a unix endpoint", unixEndpoint)
+	}
+
+	if err := removeFile(address); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("could not remove unix socket %q: %v", address, err)
 	}
 
 	return address, nil


### PR DESCRIPTION
### What does this PR do?

Fixes bug in unix endpoint parser.

### Motivation

Currently, we can install the CSI driver using helm chart thanks to [this](https://github.com/DataDog/datadog-csi-driver/pull/9) PR.

Unfortunately, we get an error when performing the following steps:

Install the CSI using helm

Uninstall the chart

Install the chart again.

The error is caused because when the CSI node server tries to start the second time, it tries to listen on the UDS socket for volume publish/unpublish requests. However, the socket is not cleaned up on uninstallation, which causes failure when attempting to listen on the socket on the second installation.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Build the CSI driver with:

```
docker build -t <image>:<tag> .
```

Install the CSI driver with:

```
helm install --set image.repository=<image> --set image.tag=<tag> datadog-csi ./chart/datadog-csi-driver 
```

Uninstall the driver with 

```
helm uninstall datadog-csi
```

Reinstall the driver again, and verify that the node server pods are in Running state.