### PR TITLE
[CONTP-688] add support for local publisher

### DIFF
--- a/pkg/driver/publishers/doc.go
+++ b/pkg/driver/publishers/doc.go
@@ -3,10 +3,8 @@ Package publishers contains the logic for publishing datadog CSI volumes dependi
 
 Datadog CSI volume request must include `mode` and `path` properties in the `volumeAttributes`.
 
-Currently, the only supported mode is `socket`.
-
-The socket publisher processes Datadog CSI volume requests by verifying that the requested path is
-indeed a socket path. If it is verified, the socket is mounted at the pod's target path. An error is
-returned otherwise.
+Supported publisher modes are:
+- socket: mounts UDS sockets.
+- local: mounts existing directories.
 */
 package publishers

--- a/pkg/driver/publishers/local.go
+++ b/pkg/driver/publishers/local.go
@@ -1,0 +1,45 @@
+package publishers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog"
+	"k8s.io/utils/mount"
+)
+
+type localPublisher struct {
+	fs      afero.Afero
+	mounter mount.Interface
+}
+
+// Mount implements Publisher#Mount.
+// It mounts directory hostPath onto directory targetPath.
+// If hostPath is not found or is not a directory, it returns an error.
+func (s localPublisher) Mount(targetPath string, hostPath string) error {
+	// Check if the target path exists. Create if not present.
+	if err := createHostPath(s.fs, targetPath, false); err != nil {
+		return fmt.Errorf("failed to create required path %q: %w", targetPath, err)
+	}
+
+	notMnt, err := s.mounter.IsLikelyNotMountPoint(targetPath)
+	if err != nil && !os.IsNotExist(err) {
+		return status.Errorf(codes.Internal, "Error checking mount point: %v", err)
+	}
+
+	if notMnt {
+		if err := s.mounter.Mount(hostPath, targetPath, "", []string{"bind"}); err != nil {
+			klog.Errorf("Failed to mount %q to %q: %v", hostPath, targetPath, err)
+			return status.Errorf(codes.Internal, "Failed to mount: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func newLocalPublisher(fs afero.Afero, mounter mount.Interface) Publisher {
+	return localPublisher{fs: fs, mounter: mounter}
+}

--- a/pkg/driver/publishers/publishers.go
+++ b/pkg/driver/publishers/publishers.go
@@ -17,10 +17,13 @@ type PublisherKind string
 const (
 	// Socket is the publisher kind that allows mounting UDS sockets.
 	Socket PublisherKind = "socket"
+	// Local is the publichser kind that allows mounting local directories.
+	Local = "local"
 )
 
 func GetPublishers(fs afero.Afero, mounter mount.Interface) map[PublisherKind]Publisher {
 	return map[PublisherKind]Publisher{
 		Socket: newSocketPublisher(fs, mounter),
+		Local:  newLocalPublisher(fs, mounter),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds a new mounting mode option: `local`.

This mode allows users to mount an existing directory via the CSI driver.

### Motivation

Be able to support 2 modes for sharing DSD/APM sockets:
* mounting the socket file: requires that the socket is already there and functional. This makes the user app dependent on the agent. If the agent fails to create the socket, the user app will fail to start.
* mounting the socket's parent directory: doesn't require that the agent is running or that the socket exists. It simply mounts an existing directory.

### Additional Notes

The CSI driver can only mount what it has access to.

For example, if the CSI daemonset mounts from the host `/var/run/datadog` as a hostpath, it will be able to satisfy CSI Volume mount requests within this directory, but it will not be able to mount other directories from the host that it doesn't have access to.

This is okay (and perhaps better) since we control what volumes and volumecontexts are sent to the CSI driver (ideally via the admission controller).

### Describe your test plan

First, deploy the CSI driver using the helm chart:

helm install --set image.repository=<repo> --set image.tag=<tag>  datadog-csi ./chart/datadog-csi-driver

Second, deploy the datadog agent with helm (use default installation, it should be enough)

Finally, deploy the following app:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadogpy
spec:
  replicas: 1
  selector:
    matchLabels:
      app: datadogpy
  template:
    metadata:
      labels:
        app: datadogpy
    spec:
      containers:
        - name: datadogpy-local
          image: adelhajhassan918/datadogpy-uds-udp
          imagePullPolicy: Always
          env:
            - name: USER
              value: "adel-local"
            - name: DD_DOGSTATSD_URL
              value: unix:///var/run/datadog/dsd.socket
          volumeMounts:
            - mountPath: /var/run/datadog
              name: dd-csi-volume-local
        - name: datadogpy-socket
          image: adelhajhassan918/datadogpy-uds-udp
          imagePullPolicy: Always
          env:
            - name: USER
              value: "adel-socket"
            - name: DD_DOGSTATSD_URL
              value: unix:///var/run/datadog/dsd.socket
          volumeMounts:
            - mountPath: /var/run/datadog/dsd.socket
              name: dd-csi-volume-socket
      volumes:
        - name: dd-csi-volume-local
          csi:
            driver: k8s.csi.datadoghq.com
            volumeAttributes:
              mode: local
              path: /var/run/datadog
        - name: dd-csi-volume-socket
          csi:
            driver: k8s.csi.datadoghq.com
            volumeAttributes:
              mode: socket
              path: /var/run/datadog/dsd.socket
```

This application has 2 identical containers sending dsd metrics over uds. The first container mounts the CSI volume with mode local, and the second one uses the mode socket.

Verify that the metrics are collected and sent to the agent:

![image](https://github.com/user-attachments/assets/9158dfc1-6665-49b6-9a09-714b2a6db1f7)

