### PR TITLE
[CONTP-731] refactor csi volume schema to eliminate the need to pass the hostpath being mounted

### DIFF
--- a/cmd/csi_registration.go
+++ b/cmd/csi_registration.go
@@ -16,7 +16,14 @@ import (
 // This is a blocking operation.
 func registerAndStartCSIDriver(ctx context.Context) error {
 	// Create CSI driver
- 	csiDriver, err := driver.NewDatadogCSIDriver(*driverNameFlag, Version)
+
+	csiDriver, err := driver.NewDatadogCSIDriver(
+		*driverNameFlag,
+		*datadogSocketsHostpath,
+		*dsdHostSocketFileName,
+		*apmHostSocketFileName,
+		Version,
+	)
 	if err != nil {
 		klog.Error(err.Error())
 		return err

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,9 +13,12 @@ import (
 )
 
 var (
-	Version        = "dev" // This will be set when building the driver
-	driverNameFlag = flag.String("driver-name", driver.CSIDriverName, "Name of the CSI driver")
-	endpointFlag   = flag.String("csi-endpoint", "unix:///csi/csi.sock", "CSI endpoint")
+	Version                = "dev" // This will be set when building the driver
+	driverNameFlag         = flag.String("driver-name", driver.CSIDriverName, "Name of the CSI driver")
+	endpointFlag           = flag.String("csi-endpoint", "unix:///csi/csi.sock", "CSI endpoint")
+	datadogSocketsHostpath = flag.String("dd-sockets-hostpath", "/var/run/datadog/", "Host path where datadog apm and dogstatsd sockets are stored")
+	dsdHostSocketFileName  = flag.String("dsd-socket-file", "dsd.socket", "Dogstatsd socket file name")
+	apmHostSocketFileName  = flag.String("apm-socket-file", "apm.socket", "APM socket file name")
 )
 
 // run creates and runs the metrics server and the csi driver grpc server

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -12,8 +12,18 @@ import (
 type DatadogCSIDriver struct {
 	csi.UnimplementedNodeServer
 	csi.UnimplementedIdentityServer
-	name       string
-	version    string
+	name    string
+	version string
+
+	// datadogSocketsHostPath is the directory in the which the datadog sockets can be found on the host
+	datadogSocketsHostPath string
+
+	// Dogstatsd socket file name
+	dsdHostSocketFileName string
+
+	// APM socket file name
+	apmHostSocketFileName string
+
 	publishers map[publishers.PublisherKind]publishers.Publisher
 	fs         afero.Afero
 	mounter    mount.Interface
@@ -25,7 +35,7 @@ func (driver *DatadogCSIDriver) Version() string {
 }
 
 // NewDatadogCSIDriver builds and returns a new Datadog CSI driver
-func NewDatadogCSIDriver(name, version string) (*DatadogCSIDriver, error) {
+func NewDatadogCSIDriver(name, datadogSocketsHostPath, dsdHostSocketFileName, apmHostSocketFileName, version string) (*DatadogCSIDriver, error) {
 	fs := afero.Afero{Fs: afero.NewOsFs()}
 	mounter := mount.New("")
 
@@ -33,6 +43,10 @@ func NewDatadogCSIDriver(name, version string) (*DatadogCSIDriver, error) {
 		name: name,
 
 		version: version,
+
+		datadogSocketsHostPath: datadogSocketsHostPath,
+		dsdHostSocketFileName:  dsdHostSocketFileName,
+		apmHostSocketFileName:  apmHostSocketFileName,
 
 		publishers: publishers.GetPublishers(fs, mounter),
 		fs:         fs,

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -36,7 +36,8 @@ func (d *DatadogCSIDriver) NodePublishVolume(ctx context.Context, req *csi.NodeP
 		volumeCtx,
 	)
 
-	ddVolumeRequest, err := NewDDVolumeRequest(req)
+	ddVolumeRequest, err := d.DDVolumeRequest(req)
+
 	if err != nil {
 		metrics.RecordVolumeMountAttempt("", "", metrics.StatusFailed)
 		return nil, fmt.Errorf("failed to create dd volume request: %v", err)
@@ -44,17 +45,17 @@ func (d *DatadogCSIDriver) NodePublishVolume(ctx context.Context, req *csi.NodeP
 
 	publisher, found := d.publishers[publishers.PublisherKind(ddVolumeRequest.mode)]
 	if !found {
-		metrics.RecordVolumeMountAttempt(ddVolumeRequest.mode, ddVolumeRequest.path, metrics.StatusFailed)
+		metrics.RecordVolumeMountAttempt(string(ddVolumeRequest.volumeType), ddVolumeRequest.path, metrics.StatusFailed)
 		return nil, fmt.Errorf("invalid mode: %q", ddVolumeRequest.mode)
 	}
 
 	err = publisher.Mount(ddVolumeRequest.targetpath, ddVolumeRequest.path)
 	if err != nil {
-		metrics.RecordVolumeMountAttempt(ddVolumeRequest.mode, ddVolumeRequest.path, metrics.StatusFailed)
+		metrics.RecordVolumeMountAttempt(string(ddVolumeRequest.volumeType), ddVolumeRequest.path, metrics.StatusFailed)
 		return nil, fmt.Errorf("failed to perform volume mount: %v", err)
 	}
 
-	metrics.RecordVolumeMountAttempt(ddVolumeRequest.mode, ddVolumeRequest.path, metrics.StatusSuccess)
+	metrics.RecordVolumeMountAttempt(string(ddVolumeRequest.volumeType), ddVolumeRequest.path, metrics.StatusSuccess)
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -2,20 +2,61 @@ package driver
 
 import (
 	"errors"
+	"fmt"
+	"path/filepath"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
+
+type VolumeType string
+
+const (
+	// APMSocket mounts the apm socket file after verifying the existence of the file
+	APMSocket VolumeType = "APMSocket"
+	// DSDSocket mounts the dogstatsd socket file after verifying the existence of the file
+	DSDSocket = "DSDSocket"
+	// DatadogSocketsDirectory mounts the directory containing the apm and dogstatsd sockets
+	DatadogSocketsDirectory = "DatadogSocketsDirectory"
+)
+
+type Mode string
+
+const (
+	// ModeSocket is the socket mode, equivalent to Socket hostpath volumes
+	ModeSocket Mode = "socket"
+	// ModeLocal is the local mode, equivalent to Directory hostpath volumes
+	ModeLocal = "local"
+)
+
+func getModeAndPath(volumeType VolumeType, datadogSocketsDirectory, dsdSocketFileName, apmSocketFileName string) (mode Mode, path string, err error) {
+	switch volumeType {
+	case APMSocket:
+		path = filepath.Join(datadogSocketsDirectory, apmSocketFileName)
+		mode = ModeSocket
+	case DSDSocket:
+		path = filepath.Join(datadogSocketsDirectory, dsdSocketFileName)
+		mode = ModeSocket
+	case DatadogSocketsDirectory:
+		path = datadogSocketsDirectory
+		mode = ModeLocal
+	default:
+		err = fmt.Errorf("unsupported volume type %q", volumeType)
+	}
+
+	return
+}
 
 // DDVolumeRequest encapsulates the properties of a request for datadog CSI volume
 type DDVolumeRequest struct {
 	volumeId   string
 	targetpath string
-	mode       string
+	volumeType VolumeType
+	mode       Mode
 	path       string
 }
 
 // NewDDVolumeRequest builds a DDVolumeRequest object based on csi node publish volume request
-func NewDDVolumeRequest(req *csi.NodePublishVolumeRequest) (*DDVolumeRequest, error) {
+func (d *DatadogCSIDriver) DDVolumeRequest(req *csi.NodePublishVolumeRequest) (*DDVolumeRequest, error) {
 	if req == nil {
 		return nil, errors.New("nil node publish volume request")
 	}
@@ -23,21 +64,21 @@ func NewDDVolumeRequest(req *csi.NodePublishVolumeRequest) (*DDVolumeRequest, er
 	targetPath := req.GetTargetPath()
 	volumeId := req.GetVolumeId()
 	volumeCtx := req.GetVolumeContext()
-	mode, foundMode := volumeCtx["mode"]
-	hostpath, foundHostPath := volumeCtx["path"]
-
-	if !foundMode {
-		return nil, errors.New("missing property 'mode' in CSI volume context")
+	volumeType, foundType := volumeCtx["type"]
+	if !foundType {
+		return nil, errors.New("missing property 'type' in CSI volume context")
 	}
 
-	if !foundHostPath {
-		return nil, errors.New("missing property 'path' in CSI volume context")
+	mode, path, err := getModeAndPath(VolumeType(volumeType), d.datadogSocketsHostPath, d.dsdHostSocketFileName, d.apmHostSocketFileName)
+	if err != nil {
+		return nil, err
 	}
 
 	return &DDVolumeRequest{
 		volumeId:   volumeId,
 		targetpath: targetPath,
+		volumeType: VolumeType(volumeType),
 		mode:       mode,
-		path:       hostpath,
+		path:       path,
 	}, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,7 +31,7 @@ func newCounterVec(name, help string, labels ...string) *prometheus.CounterVec {
 var nodeVolumeMountAttempts = newCounterVec(
 	"node_publish_volume_attempts",
 	"Counts the number of publish volume requests received by the csi node server",
-	"mode",
+	"type",
 	"path",
 	"status",
 )
@@ -49,8 +49,8 @@ func init() {
 }
 
 // RecordVolumeMountAttempt records a volume mount attempt
-func RecordVolumeMountAttempt(mode, path string, status Status) {
-	nodeVolumeMountAttempts.WithLabelValues(mode, path, string(status)).Inc()
+func RecordVolumeMountAttempt(volumeType, path string, status Status) {
+	nodeVolumeMountAttempts.WithLabelValues(volumeType, path, string(status)).Inc()
 }
 
 // RecordVolumeUnMountAttempt records a volume unmount attempt


### PR DESCRIPTION
### What does this PR do?

This PR changes the schema of the CSI volume attributes so that:
- We don't need to specify a host path in the volume attributes
- The schema is more strict and simplified

The previous schema looked as follows:
```
csi:
    driver: k8s.csi.datadoghq.com
    volumeAttributes:
        mode: socket
        path: /var/run/datadog/dsd.socket
name: datadog-dsd
```

The new schema provides a predefined static set of volume types:
- `DatadogSocketsDirectory`: used to mount the directory from the host where the apm and dsd sockets live. (Equivalent to Directory hostpath mount)
- `DSDSocket`: used to mount dogstatsd socket file (equivalent to `Socket` hostpath mount)
- `APMSocket`: same as `DSDSocket` but for APM socket.

(see QA section for examples)

### Motivation

- Improve security posture
- Make it easier to configure/use

### Additional Notes

The following assumption was made: **APM and Dogstatsd sockets live in the same directory on the host.**

Why?
- If not, we will have to deal with the case where we might try to mount 2 different path to the same mount point, which is problematic.
-  There is no valid use case where having different parent hostpaths for these sockets is useful (correct me if I am missing something)

Once this change is approved and merged, we need to do the following:
* update the helm chart so that we can configure the sockets paths
* update the DCA to adapt to the new schema
* update the README
* update the documentation

### Describe your test plan

On a kind cluster, deploy the CSI driver using the helm chart:

```
helm install --set image.repository=<repo> --set image.tag=<tag> datadog-csi ./chart/datadog-csi-driver
```

Install datadog agent using helm chart with the default installation options.
This should create `apm.sock` and `dsd.sock` under `/var/run/datadog`.

Create the following deployment for testing:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-app
  template:
    metadata:
      labels:
        app: dummy-app
    spec:
      containers:
        - name: ubuntu
          image: ubuntu
          command: ["/bin/bash", "-c", "--"]
          args: ["while true; do sleep 30; echo hello-ubuntu; done;"]
          volumeMounts:
            - mountPath: /var/sockets/all
              name: dd-csi-volume-all
            - mountPath: /var/sockets/apm/apm.sock
              name: dd-csi-volume-apm
            - mountPath: /var/sockets/dsd/dsd.sock
              name: dd-csi-volume-dsd
      volumes:
        - name: dd-csi-volume-all
          csi:
            driver: k8s.csi.datadoghq.com
            volumeAttributes:
              type: DatadogSocketsDirectory
        - name: dd-csi-volume-dsd
          csi:
            driver: k8s.csi.datadoghq.com
            volumeAttributes:
              type: DSDSocket
        - name: dd-csi-volume-apm
          csi:
            driver: k8s.csi.datadoghq.com
            volumeAttributes:
              type: APMSocket
```

Make sure the pod can start, indicating the mount was successfull.

SSH into the pod and check the mounts are correct:
```
# ls /var/sockets/all
apm.socket  dsd.socket
# ls /var/sockets/apm
apm.sock
# ls /var/sockets/dsd
dsd.sock
```

You can also try the following: 
- Try using a CSI volume without specifying a type: the pod is expected to be stuck in ContainerCreating phase, and you should see an error regarding missing volume type attribute in the pod describe events
- Try changing the host socket path in the agent installation (see `datadog.apm.hostSocketPath` and `datadog.dsd.hostSocketPath`) and try again.