### PR TITLE
restore backward compatibility

### DIFF
--- a/test/e2e/main_e2e_test.go
+++ b/test/e2e/main_e2e_test.go
@@ -49,6 +49,22 @@ func TestUDSConsumerPod(t *testing.T) {
 			podName:     "consumer-apmsocketdirectory",
 			expectedLog: "Hello from APMSocketDirectory",
 		},
+		{
+			podName:     "deprecated-consumer-dsdsocket",
+			expectedLog: "Hello from deprecated DSDSocket",
+		},
+		{
+			podName:     "deprecated-consumer-dsdsocketdirectory",
+			expectedLog: "Hello from deprecated DSDSocketDirectory",
+		},
+		{
+			podName:     "deprecated-consumer-apmsocket",
+			expectedLog: "Hello from deprecated APMSocket",
+		},
+		{
+			podName:     "deprecated-consumer-apmsocketdirectory",
+			expectedLog: "Hello from deprecated APMSocketDirectory",
+		},
 	}
 
 	t.Log("Waiting for consumer pods to be Ready...")

--- a/test/e2e/manifests/deprecated-consumer-apmsocket.yaml
+++ b/test/e2e/manifests/deprecated-consumer-apmsocket.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deprecated-consumer-apmsocket
+spec:
+  containers:
+  - name: deprecated-consumer-apmsocket
+    image: alpine/socat
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        while true; do
+          echo "Hello from deprecated APMSocket" | socat - UNIX-CONNECT:/apm.sock;
+          sleep 1;
+        done
+    volumeMounts:
+    - name: dd-csi-volume
+      mountPath: /apm.sock
+  volumes:
+  - name: dd-csi-volume
+    csi:
+      driver: k8s.csi.datadoghq.com
+      volumeAttributes:
+        mode: socket
+        path: /socket-dir/apm.sock

--- a/test/e2e/manifests/deprecated-consumer-apmsocketdirectory.yaml
+++ b/test/e2e/manifests/deprecated-consumer-apmsocketdirectory.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deprecated-consumer-apmsocketdirectory
+spec:
+  containers:
+  - name: deprecated-consumer-apmsocketdirectory
+    image: alpine/socat
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        while true; do
+          echo "Hello from deprecated APMSocketDirectory" | socat - UNIX-CONNECT:/csi-mount/apm.sock;
+          sleep 1;
+        done
+    volumeMounts:
+    - name: dd-csi-volume
+      mountPath: /csi-mount
+  volumes:
+  - name: dd-csi-volume
+    csi:
+      driver: k8s.csi.datadoghq.com
+      volumeAttributes:
+        mode: local
+        path: /socket-dir

--- a/test/e2e/manifests/deprecated-consumer-dsdsocket.yaml
+++ b/test/e2e/manifests/deprecated-consumer-dsdsocket.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deprecated-consumer-dsdsocket
+spec:
+  containers:
+  - name: deprecated-consumer-dsdsocket
+    image: alpine/socat
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        while true; do
+          echo "Hello from deprecated DSDSocket" | socat - UNIX-CONNECT:/dsd.sock;
+          sleep 1;
+        done
+    volumeMounts:
+    - name: dd-csi-volume
+      mountPath: /dsd.sock
+  volumes:
+  - name: dd-csi-volume
+    csi:
+      driver: k8s.csi.datadoghq.com
+      volumeAttributes:
+        mode: socket
+        path: /socket-dir/dsd.sock

--- a/test/e2e/manifests/deprecated-consumer-dsdsocketdirectory.yaml
+++ b/test/e2e/manifests/deprecated-consumer-dsdsocketdirectory.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deprecated-consumer-dsdsocketdirectory
+spec:
+  containers:
+  - name: deprecated-consumer-dsdsocketdirectory
+    image: alpine/socat
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        while true; do
+          echo "Hello from deprecated DSDSocketDirectory" | socat - UNIX-CONNECT:/csi-mount/dsd.sock;
+          sleep 1;
+        done
+    volumeMounts:
+    - name: dd-csi-volume
+      mountPath: /csi-mount
+  volumes:
+  - name: dd-csi-volume
+    csi:
+      driver: k8s.csi.datadoghq.com
+      volumeAttributes:
+        mode: local
+        path: /socket-dir

--- a/test/e2e/setup-env.sh
+++ b/test/e2e/setup-env.sh
@@ -5,7 +5,7 @@ CLUSTER_NAME="csi-e2e"
 HELM_RELEASE="datadog-csi"
 NAMESPACE="datadog"
 IMAGE_NAME="datadog-csi-driver:dev"
-PLATFORM="linux/amd64"
+PLATFORM="linux/$(uname -m)"
 
 # Check if the cluster already exists and delete it
 echo "🧱 [1/5] Checking if Kind cluster already exists..."


### PR DESCRIPTION
### What does this PR do?

[A previous PR](https://github.com/DataDog/datadog-csi-driver/pull/23) changed the schema of the the volume attributes of the Datadog CSI Driver.

Version 7.65 of the cluster agent injects CSI volume based on the old schema. 

This causes failure in case of using the CSI driver with v7.65 of the cluster agent. 

This PR tries aims to restore backward compatibility so that if the CSI driver is used with the DCA v7.65, it doesn't break.

### Additional Notes

* An extra validation is done in case the old schema is used to make sure that it maps correctly to the new schema.

### Describe your test plan

- Unit tests still work. 
- E2E tests
- Manual testing: deployed CSI driver with dca v7.65 and verified that the app works fine.