### PR TITLE
handle DatadogSocketsDirectory VolumeType

### DIFF
--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"k8s.io/klog/v2"
 )
 
 type VolumeType string
@@ -27,6 +28,10 @@ const (
 
 	// DSDSocketDirectory mounts the parent directory of the dogstatsd socket
 	DSDSocketDirectory VolumeType = "DSDSocketDirectory"
+
+	// DatadogSocketsDirectory mounts the parent directory of the dogstatsd socket
+	// This option is deprecated, but kept to avoid breaking backward compatibility
+	DatadogSocketsDirectory VolumeType = "DatadogSocketsDirectory"
 )
 
 type Mode string
@@ -50,6 +55,10 @@ func getModeAndPath(volumeType VolumeType, apmHostSocketPath, dsdHostSocketPath 
 		path = dsdHostSocketPath
 		mode = ModeSocket
 	case DSDSocketDirectory:
+		path = filepath.Dir(dsdHostSocketPath)
+		mode = ModeLocal
+	case DatadogSocketsDirectory:
+		klog.Warningf("%s volume type is deprecated. Prefer using %s or %s instead.", DatadogSocketsDirectory, DSDSocketDirectory, APMSocketDirectory)
 		path = filepath.Dir(dsdHostSocketPath)
 		mode = ModeLocal
 	default:

--- a/test/e2e/main_e2e_test.go
+++ b/test/e2e/main_e2e_test.go
@@ -65,6 +65,10 @@ func TestUDSConsumerPod(t *testing.T) {
 			podName:     "deprecated-consumer-apmsocketdirectory",
 			expectedLog: "Hello from deprecated APMSocketDirectory",
 		},
+		{
+			podName:     "deprecated-consumer-datadogsocketsdirectory",
+			expectedLog: "Hello from deprecated DatadogSocketsDirectory",
+		},
 	}
 
 	t.Log("Waiting for consumer pods to be Ready...")

--- a/test/e2e/manifests/consumer-datadogsocketsdirectory.yaml
+++ b/test/e2e/manifests/consumer-datadogsocketsdirectory.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deprecated-consumer-datadogsocketsdirectory
+spec:
+  containers:
+  - name: deprecated-consumer-datadogsocketsdirectory
+    image: alpine/socat
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        while true; do
+          echo "Hello from deprecated DatadogSocketsDirectory" | socat - UNIX-CONNECT:/csi-mount/dsd.sock;
+          sleep 1;
+        done
+    volumeMounts:
+    - name: dd-csi-volume
+      mountPath: /csi-mount
+  volumes:
+  - name: dd-csi-volume
+    csi:
+      driver: k8s.csi.datadoghq.com
+      volumeAttributes:
+        type: DatadogSocketsDirectory


### PR DESCRIPTION
### What does this PR do?

Handle `DatadogSocketsDirectory` volume type without breaking user app.

### Motivation

Version 7.66 of the admission controller had a bug where it was injecting `DatadogSocketsDirectory` volume type instead of `DSDSocketDirectory` and `APMSocketDirectory`. 

The CSI driver is already not supported for version 7.66. But this PR serves as a prevention that avoids breaking user apps in case they accidentally tested CSI driver with v7.66 of the agent. 


### Describe your test plan

Updated e2e tests