### PR TITLE
[CONTP-1066] Release latest internally when releasing on main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,3 +116,22 @@ trigger_internal_image:
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
+
+trigger_internal_image_latest:
+  stage: release
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: on_success
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v1
+    IMAGE_NAME: $PROJECTNAME
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    TMPL_SRC_IMAGE: latest
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"


### PR DESCRIPTION
### What does this PR do?

Release image with tag 'latest' internally on successful merge on main.

### Motivation

Vulnerability scanning for datadog csi driver is trying to fetch the latest image of csi driver. 

However, internally we only release images having the the pipeline id + commit short sha as a tag, resulting in failing the vulnerability scan. 
