### PR TITLE
Release latest internally when releasing on main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,8 +130,8 @@ trigger_internal_image_latest:
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME
-    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
+    RELEASE_TAG: latest
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}
-    TMPL_SRC_IMAGE: latest
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"


### PR DESCRIPTION
### What does this PR do?

Amends[ a previous PR](https://github.com/DataDog/datadog-csi-driver/pull/40), fixing CI job vars.

`latest` should be set as the release_tag, instead of as the src tag.