### PR TITLE
[CONTP-1066] release main instead of latest internally on merge on main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,7 +117,7 @@ trigger_internal_image:
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
-trigger_internal_image_latest:
+trigger_internal_image_main:
   stage: release
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
@@ -130,8 +130,8 @@ trigger_internal_image_latest:
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME
-    RELEASE_TAG: latest
-    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    RELEASE_TAG: main
+    BUILD_TAG: main
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"


### PR DESCRIPTION
### What does this PR do?

Use `main` tag instead of `latest` when releasing internally on merge on main.
