### PR TITLE
[CONTP-1066] Bump golang version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Go",
-    "image": "mcr.microsoft.com/devcontainers/go:1-1.23",
+    "image": "mcr.microsoft.com/devcontainers/go:1-1.24",
     "features": {
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
         "ghcr.io/devcontainers-contrib/features/kubectx-kubens": {},

--- a/.github/workflows/golang-ci-linter.yaml
+++ b/.github/workflows/golang-ci-linter.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Lint code
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Run Unit Tests
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
-image: registry.ddbuild.io/images/mirror/golang:1.23.4
+image: registry.ddbuild.io/images/mirror/golang:1.24
 variables:
   PROJECTNAME: "datadog-csi-driver"
   BUILD_DOCKER_REGISTRY: "registry.ddbuild.io/ci"
@@ -18,7 +18,7 @@ stages:
 
 tests:
   stage: test
-  image: registry.ddbuild.io/images/mirror/golang:1.23.4
+  image: registry.ddbuild.io/images/mirror/golang:1.24
   tags: ["arch:amd64"]
   script:
     - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The base image is already multi-architecture, supporting both amd64 and arm64.
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Datadog/datadog-csi-driver
 
-go 1.23.4
+go 1.24
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
### What does this PR do?

Bumps go version.

### Motivation

Resolve several CVEs. For example:

- [CVE-2025-58187](https://avd.aquasec.com/nvd/cve-2025-58187)
- [CVE-2025-61724](https://avd.aquasec.com/nvd/cve-2025-61724)
- [CVE-2025-58186](https://avd.aquasec.com/nvd/cve-2025-58186)
- [CVE-2025-58188](https://avd.aquasec.com/nvd/cve-2025-58188)
- [CVE-2025-47912](https://avd.aquasec.com/nvd/cve-2025-47912)
- [CVE-2025-58183](https://avd.aquasec.com/nvd/cve-2025-58183)

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.