### PR TITLE
[CONTP-1194] bump golang version to fix CVE

### DIFF
--- a/.github/workflows/golang-ci-linter.yaml
+++ b/.github/workflows/golang-ci-linter.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.24"
+          go-version: "1.24.11"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Lint code
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.24"
+          go-version: "1.24.11"
 
       - name: Run Unit Tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The base image is already multi-architecture, supporting both amd64 and arm64.
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24.11-alpine AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Datadog/datadog-csi-driver
 
 go 1.24.0
 
-toolchain go1.24.4
+toolchain go1.24.11
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
### What does this PR do?

Fixes Vulnerability: [CVE-2025-61729](https://avd.aquasec.com/nvd/cve-2025-61729)