### PR TITLE
Publish a ConfigMap to expose the CSI driver config

### DIFF
--- a/cmd/csi_registration.go
+++ b/cmd/csi_registration.go
@@ -38,6 +38,15 @@ func registerAndStartCSIDriver(ctx context.Context) error {
 	// Log the version
 	log.Info("Created Datadog CSI Driver", "version", csiDriver.Version())
 
+	// Publish driver configuration to ConfigMap for discovery by other components
+	if err := driver.PublishConfigMap(ctx, driver.DriverConfig{
+		Version:    Version,
+		SSIEnabled: !viper.GetBool("disable-ssi"),
+	}); err != nil {
+		log.Warn("Failed to publish driver config to ConfigMap", "error", err)
+		// Don't fail startup, this is not critical
+	}
+
 	// Setup grpc server
 	// TODO: check if it is necessary to use TLS in the grpc server
 	grpcServer := grpc.NewServer()

--- a/go.mod
+++ b/go.mod
@@ -101,9 +101,9 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	go.etcd.io/bbolt v1.4.3
-	k8s.io/api v0.28.3
-	k8s.io/apimachinery v0.28.3
-	k8s.io/client-go v0.28.3
+	k8s.io/api v0.32.0
+	k8s.io/apimachinery v0.32.0
+	k8s.io/client-go v0.32.0
 )
 
 replace (

--- a/pkg/driver/configmap.go
+++ b/pkg/driver/configmap.go
@@ -1,0 +1,101 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package driver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	ConfigMapName = "datadog-csi-driver-config"
+
+	// Keys in the ConfigMap
+	KeyVersion    = "version"
+	KeySSIEnabled = "ssi_enabled"
+)
+
+// DriverConfig holds the configuration to publish
+type DriverConfig struct {
+	Version    string
+	SSIEnabled bool
+}
+
+// PublishConfigMap creates or updates a ConfigMap with driver configuration.
+// This allows other components (like the cluster-agent) to discover the driver's capabilities.
+func PublishConfigMap(ctx context.Context, config DriverConfig) error {
+	namespace, err := getNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to determine namespace: %w", err)
+	}
+
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get in-cluster config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	ssiEnabledStr := "false"
+	if config.SSIEnabled {
+		ssiEnabledStr = "true"
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConfigMapName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "datadog-csi-driver",
+				"app.kubernetes.io/managed-by": "datadog-csi-driver",
+			},
+		},
+		Data: map[string]string{
+			KeyVersion:    config.Version,
+			KeySSIEnabled: ssiEnabledStr,
+		},
+	}
+
+	_, err = clientset.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		// ConfigMap already exists, update it
+		_, err = clientset.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create/update configmap: %w", err)
+	}
+
+	slog.Info("Published driver configuration to ConfigMap",
+		"namespace", namespace,
+		"name", ConfigMapName,
+		"version", config.Version,
+		"ssi_enabled", ssiEnabledStr,
+	)
+
+	return nil
+}
+
+// getNamespace returns the namespace the pod is running in.
+// It reads from the service account token mount, which is always present in-cluster.
+func getNamespace() (string, error) {
+	// Read from service account (standard in-cluster location)
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", fmt.Errorf("cannot read namespace from service account: %w", err)
+	}
+	return string(data), nil
+}


### PR DESCRIPTION
### What does this PR do?

Adds a ConfigMap publication mechanism to the CSI driver. At startup, the driver creates/updates a ConfigMap (`datadog-csi-driver-config`) in its namespace containing:
- `version`: the driver version
- `ssi_enabled`: whether SSI support is enabled

### Motivation

Allow the Cluster Agent to discover the CSI driver's capabilities and configuration. This enables the Cluster Agent to choose alternative injection methods when the CSI driver has SSI disabled.

### Additional Notes

- The ConfigMap is created in the same namespace as the CSI driver (read from service account token mount)
- If namespace detection fails, the driver logs an error but continues to start
- Requires RBAC permissions for the CSI driver to create/update ConfigMaps in its namespace

### Describe your test plan

- Deploy CSI driver with SSI enabled, verify ConfigMap contains `ssi_enabled: true`
- Deploy CSI driver with `--disable-ssi`, verify ConfigMap contains `ssi_enabled: false`
- Verify ConfigMap is updated on driver restart