### PR TITLE
Add registry allow list for DatadogLibrary CSI volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `--registry-allow-list` flag (env: `DD_REGISTRY_ALLOW_LIST`) for `DatadogLibrary` volumes. When non-empty, only registries in the list are permitted; requests specifying an unlisted registry are rejected. Empty list (default) allows all registries.
+
 ## [1.2.1] - 2026-02-03
 
 ### Fixed

--- a/cmd/csi_registration.go
+++ b/cmd/csi_registration.go
@@ -29,6 +29,7 @@ func registerAndStartCSIDriver(ctx context.Context) error {
 		viper.GetString("storage-path"),
 		Version,
 		viper.GetBool("apm-enabled"),
+		viper.GetStringSlice("registry-allow-list"),
 	)
 	if err != nil {
 		log.Error("Failed to create CSI driver", "error", err)

--- a/cmd/csi_registration.go
+++ b/cmd/csi_registration.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	log "log/slog"
 	"net"
+	"strings"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/driver"
 	"github.com/Datadog/datadog-csi-driver/utils"
@@ -29,7 +30,7 @@ func registerAndStartCSIDriver(ctx context.Context) error {
 		viper.GetString("storage-path"),
 		Version,
 		viper.GetBool("apm-enabled"),
-		viper.GetStringSlice("registry-allow-list"),
+		getRegistryAllowList(),
 	)
 	if err != nil {
 		log.Error("Failed to create CSI driver", "error", err)
@@ -80,4 +81,20 @@ func registerAndStartCSIDriver(ctx context.Context) error {
 	case <-ctx.Done():
 		return nil
 	}
+}
+
+// getRegistryAllowList returns the registry allow list, handling the case where
+// Viper returns a comma-separated env var as a single element instead of splitting it.
+func getRegistryAllowList() []string {
+	raw := viper.GetStringSlice("registry-allow-list")
+	var result []string
+	for _, item := range raw {
+		for _, r := range strings.Split(item, ",") {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				result = append(result, r)
+			}
+		}
+	}
+	return result
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,10 @@ func init() {
 	// Env var: DD_APM_ENABLED
 	pflag.Bool("apm-enabled", true, "Enable APM/SSI publishers (library and injector preload)")
 
+	// Allowed registries for DatadogLibrary volumes. If empty, all registries are allowed.
+	// Env var: DD_REGISTRY_ALLOW_LIST (comma-separated)
+	pflag.StringSlice("registry-allow-list", []string{}, "Allowed registries for DatadogLibrary volumes. If empty, all registries are allowed.")
+
 	// Parse flags
 	pflag.Parse()
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -46,7 +46,7 @@ func (driver *DatadogCSIDriver) Stop() error {
 }
 
 // NewDatadogCSIDriver builds and returns a new Datadog CSI driver
-func NewDatadogCSIDriver(name, apmHostSocketPath, dsdHostSocketPath, storageBasePath, version string, apmEnabled bool) (*DatadogCSIDriver, error) {
+func NewDatadogCSIDriver(name, apmHostSocketPath, dsdHostSocketPath, storageBasePath, version string, apmEnabled bool, allowedRegistries []string) (*DatadogCSIDriver, error) {
 	fs := afero.Afero{Fs: afero.NewOsFs()}
 	mounter := mount.New("")
 
@@ -67,7 +67,7 @@ func NewDatadogCSIDriver(name, apmHostSocketPath, dsdHostSocketPath, storageBase
 		name:    name,
 		version: version,
 
-		publisher:      publishers.GetPublishers(fs, mounter, apmHostSocketPath, dsdHostSocketPath, storageBasePath, lm, apmEnabled),
+		publisher:      publishers.GetPublishers(fs, mounter, apmHostSocketPath, dsdHostSocketPath, storageBasePath, lm, apmEnabled, allowedRegistries),
 		libraryManager: lm,
 		fs:             fs,
 		mounter:        mounter,

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -78,6 +78,7 @@ func TestNewDatadogCSIDriver_CreatesLibraryManagerWhenStoragePathIsWritable(t *t
 		storageBasePath,
 		"test-version",
 		true,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -106,6 +107,7 @@ func TestNewDatadogCSIDriver_DisablesSSIStorageWhenStoragePathIsNotWritable(t *t
 		"/var/datadog",
 		"test-version",
 		true,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -56,14 +56,12 @@ func (d *DatadogCSIDriver) NodeUnpublishVolume(_ context.Context, req *csi.NodeU
 	resp, err := d.publisher.Unpublish(req)
 	if err != nil {
 		metrics.RecordVolumeUnMountAttempt(metrics.StatusFailed)
-		log.Error("failed to unpublish volume", "error", err)
-		return &csi.NodeUnpublishVolumeResponse{}, nil
+		return nil, fmt.Errorf("failed to unpublish volume: %v", err)
 	}
 
 	if resp == nil {
 		metrics.RecordVolumeUnMountAttempt(metrics.StatusUnsupported)
-		log.Error("unpublish volume request not supported by any publisher")
-		return &csi.NodeUnpublishVolumeResponse{}, nil
+		return nil, fmt.Errorf("unpublish volume request not supported by any publisher")
 	}
 
 	metrics.RecordVolumeUnMountAttempt(metrics.StatusSuccess)

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -7,6 +7,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	log "log/slog"
 	"os"
 
@@ -34,15 +35,13 @@ func (d *DatadogCSIDriver) NodePublishVolume(_ context.Context, req *csi.NodePub
 	if err != nil {
 		volumeCtx := req.GetVolumeContext()
 		metrics.RecordVolumeMountAttempt(volumeCtx["type"], req.GetTargetPath(), metrics.StatusFailed)
-		log.Error("failed to publish volume, pod will start without this volume's content", "error", err)
-		return &csi.NodePublishVolumeResponse{}, nil
+		return nil, fmt.Errorf("failed to publish volume: %v", err)
 	}
 
 	if resp == nil {
 		volumeCtx := req.GetVolumeContext()
 		metrics.RecordVolumeMountAttempt(volumeCtx["type"], req.GetTargetPath(), metrics.StatusUnsupported)
-		log.Error("unsupported volume type, pod will start without this volume's content", "type", volumeCtx["type"])
-		return &csi.NodePublishVolumeResponse{}, nil
+		return nil, fmt.Errorf("unsupported volume type: %q", volumeCtx["type"])
 	}
 
 	metrics.RecordVolumeMountAttempt(string(resp.VolumeType), resp.VolumePath, metrics.StatusSuccess)

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -7,7 +7,6 @@ package driver
 
 import (
 	"context"
-	"fmt"
 	log "log/slog"
 	"os"
 
@@ -35,13 +34,15 @@ func (d *DatadogCSIDriver) NodePublishVolume(_ context.Context, req *csi.NodePub
 	if err != nil {
 		volumeCtx := req.GetVolumeContext()
 		metrics.RecordVolumeMountAttempt(volumeCtx["type"], req.GetTargetPath(), metrics.StatusFailed)
-		return nil, fmt.Errorf("failed to publish volume: %v", err)
+		log.Error("failed to publish volume, pod will start without this volume's content", "error", err)
+		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
 	if resp == nil {
 		volumeCtx := req.GetVolumeContext()
 		metrics.RecordVolumeMountAttempt(volumeCtx["type"], req.GetTargetPath(), metrics.StatusUnsupported)
-		return nil, fmt.Errorf("unsupported volume type: %q", volumeCtx["type"])
+		log.Error("unsupported volume type, pod will start without this volume's content", "type", volumeCtx["type"])
+		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
 	metrics.RecordVolumeMountAttempt(string(resp.VolumeType), resp.VolumePath, metrics.StatusSuccess)
@@ -56,12 +57,14 @@ func (d *DatadogCSIDriver) NodeUnpublishVolume(_ context.Context, req *csi.NodeU
 	resp, err := d.publisher.Unpublish(req)
 	if err != nil {
 		metrics.RecordVolumeUnMountAttempt(metrics.StatusFailed)
-		return nil, fmt.Errorf("failed to unpublish volume: %v", err)
+		log.Error("failed to unpublish volume", "error", err)
+		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 
 	if resp == nil {
 		metrics.RecordVolumeUnMountAttempt(metrics.StatusUnsupported)
-		return nil, fmt.Errorf("unpublish volume request not supported by any publisher")
+		log.Error("unpublish volume request not supported by any publisher")
+		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 
 	metrics.RecordVolumeUnMountAttempt(metrics.StatusSuccess)

--- a/pkg/driver/publishers/library.go
+++ b/pkg/driver/publishers/library.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
@@ -59,8 +60,8 @@ func (s libraryPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publisher
 	}
 
 	registry := volumeCtx[keyLibraryRegistry]
-	if err := checkRegistryAllowed(registry, s.allowedRegistries); err != nil {
-		return &PublisherResponse{VolumeType: DatadogLibrary}, err
+	if !s.registryAllowed(registry) {
+		return &PublisherResponse{VolumeType: DatadogLibrary}, fmt.Errorf("registry %q is not in the allow list", registry)
 	}
 
 	libraryPath, image, err := s.getLibraryPath(volumeCtx, req.GetVolumeId())
@@ -145,15 +146,10 @@ func newLibraryPublisher(fs afero.Afero, mounter mount.Interface, libraryManager
 	return libraryPublisher{fs: fs, mounter: mounter, libraryManager: libraryManager, disabled: disabled, allowedRegistries: allowedRegistries}
 }
 
-// checkRegistryAllowed returns nil if the registry is in the allow list, or if the allow list is empty.
-func checkRegistryAllowed(registry string, allowed []string) error {
-	if len(allowed) == 0 {
-		return nil
+// registryAllowed returns true if the registry is in libraryPublisher's list of allowed registries, or if the list is nil (allow all).
+func (s *libraryPublisher) registryAllowed(registry string) bool {
+	if len(s.allowedRegistries) == 0 {
+		return true
 	}
-	for _, r := range allowed {
-		if r == registry {
-			return nil
-		}
-	}
-	return fmt.Errorf("registry %q is not in the allow list", registry)
+	return slices.Contains(s.allowedRegistries, registry)
 }

--- a/pkg/driver/publishers/library.go
+++ b/pkg/driver/publishers/library.go
@@ -36,6 +36,9 @@ type libraryPublisher struct {
 	libraryManager *librarymanager.LibraryManager
 	// disabled indicates if SSI is disabled (publish requests will be rejected)
 	disabled bool
+	// allowedRegistries is the list of registries that are allowed to be used.
+	// If empty, all registries are allowed.
+	allowedRegistries []string
 }
 
 // Publish downloads the library from the OCI registry if needed and bind-mounts it to the target path.
@@ -53,6 +56,11 @@ func (s libraryPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publisher
 	// Defensive code: library volumes must be mounted in read-only mode to protect the shared store
 	if !req.GetReadonly() {
 		return &PublisherResponse{VolumeType: DatadogLibrary}, fmt.Errorf("library volumes must be mounted in read-only mode")
+	}
+
+	registry := volumeCtx[keyLibraryRegistry]
+	if err := checkRegistryAllowed(registry, s.allowedRegistries); err != nil {
+		return &PublisherResponse{VolumeType: DatadogLibrary}, err
 	}
 
 	libraryPath, image, err := s.getLibraryPath(volumeCtx, req.GetVolumeId())
@@ -133,6 +141,19 @@ func (s libraryPublisher) getLibraryPath(volumeCtx map[string]string, volumeID s
 	return path, lib.Image(), nil
 }
 
-func newLibraryPublisher(fs afero.Afero, mounter mount.Interface, libraryManager *librarymanager.LibraryManager, disabled bool) Publisher {
-	return libraryPublisher{fs: fs, mounter: mounter, libraryManager: libraryManager, disabled: disabled}
+func newLibraryPublisher(fs afero.Afero, mounter mount.Interface, libraryManager *librarymanager.LibraryManager, disabled bool, allowedRegistries []string) Publisher {
+	return libraryPublisher{fs: fs, mounter: mounter, libraryManager: libraryManager, disabled: disabled, allowedRegistries: allowedRegistries}
+}
+
+// checkRegistryAllowed returns nil if the registry is in the allow list, or if the allow list is empty.
+func checkRegistryAllowed(registry string, allowed []string) error {
+	if len(allowed) == 0 {
+		return nil
+	}
+	for _, r := range allowed {
+		if r == registry {
+			return nil
+		}
+	}
+	return fmt.Errorf("registry %q is not in the allow list", registry)
 }

--- a/pkg/driver/publishers/library_test.go
+++ b/pkg/driver/publishers/library_test.go
@@ -208,43 +208,38 @@ func TestLibraryPublisher_Publish_Success(t *testing.T) {
 		"mount source should contain library path, got: %s", mountLog[0].Source)
 }
 
-func TestCheckRegistryAllowed(t *testing.T) {
+func TestRegistryAllowed(t *testing.T) {
 	tests := map[string]struct {
-		registry  string
-		allowed   []string
-		expectErr bool
+		registry      string
+		allowed       []string
+		expectAllowed bool
 	}{
 		"empty allow list permits any registry": {
-			registry:  "gcr.io/untrusted",
-			allowed:   []string{},
-			expectErr: false,
+			registry:      "gcr.io/untrusted",
+			allowed:       []string{},
+			expectAllowed: true,
 		},
 		"nil allow list permits any registry": {
-			registry:  "gcr.io/untrusted",
-			allowed:   nil,
-			expectErr: false,
+			registry:      "gcr.io/untrusted",
+			allowed:       nil,
+			expectAllowed: true,
 		},
 		"listed registry is permitted": {
-			registry:  "gcr.io/datadoghq",
-			allowed:   []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"},
-			expectErr: false,
+			registry:      "gcr.io/datadoghq",
+			allowed:       []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"},
+			expectAllowed: true,
 		},
 		"unlisted registry is rejected": {
-			registry:  "gcr.io/untrusted",
-			allowed:   []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"},
-			expectErr: true,
+			registry:      "gcr.io/untrusted",
+			allowed:       []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"},
+			expectAllowed: false,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := checkRegistryAllowed(tc.registry, tc.allowed)
-			if tc.expectErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "not in the allow list")
-			} else {
-				assert.NoError(t, err)
-			}
+			publisher := &libraryPublisher{allowedRegistries: tc.allowed}
+			assert.Equal(t, tc.expectAllowed, publisher.registryAllowed(tc.registry))
 		})
 	}
 }

--- a/pkg/driver/publishers/library_test.go
+++ b/pkg/driver/publishers/library_test.go
@@ -175,7 +175,7 @@ func TestLibraryPublisher_Publish_Success(t *testing.T) {
 
 	// Create publisher
 	mounter := mount.NewFakeMounter(nil)
-	publisher := newLibraryPublisher(fs, mounter, lm, false)
+	publisher := newLibraryPublisher(fs, mounter, lm, false, nil)
 
 	// Create target directory
 	targetPath := filepath.Join(t.TempDir(), "target", "library")
@@ -208,6 +208,118 @@ func TestLibraryPublisher_Publish_Success(t *testing.T) {
 		"mount source should contain library path, got: %s", mountLog[0].Source)
 }
 
+func TestCheckRegistryAllowed(t *testing.T) {
+	tests := map[string]struct {
+		registry  string
+		allowed   []string
+		expectErr bool
+	}{
+		"empty allow list permits any registry": {
+			registry:  "gcr.io/untrusted",
+			allowed:   []string{},
+			expectErr: false,
+		},
+		"nil allow list permits any registry": {
+			registry:  "gcr.io/untrusted",
+			allowed:   nil,
+			expectErr: false,
+		},
+		"listed registry is permitted": {
+			registry:  "gcr.io/datadoghq",
+			allowed:   []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"},
+			expectErr: false,
+		},
+		"unlisted registry is rejected": {
+			registry:  "gcr.io/untrusted",
+			allowed:   []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"},
+			expectErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := checkRegistryAllowed(tc.registry, tc.allowed)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "not in the allow list")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLibraryPublisher_Publish_RegistryAllowList(t *testing.T) {
+	// Setup local registry with test image
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	localRegistry.AddImage(t, "../../librarymanager/testdata/image.tar", "test-image", "v1.0.0")
+
+	// Create temp directory for library manager
+	basePath := t.TempDir()
+
+	// Create library manager with test downloader
+	fs := afero.Afero{Fs: afero.NewOsFs()}
+	lm, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(fs),
+		librarymanager.WithDownloader(librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))),
+	)
+	require.NoError(t, err)
+	defer lm.Stop()
+
+	mounter := mount.NewFakeMounter(nil)
+	registryHost := localRegistry.Registry(t)
+
+	tests := map[string]struct {
+		allowedRegistries []string
+		expectErr         bool
+	}{
+		"empty allow list permits the request": {
+			allowedRegistries: []string{},
+			expectErr:         false,
+		},
+		"allowed registry succeeds": {
+			allowedRegistries: []string{registryHost},
+			expectErr:         false,
+		},
+		"disallowed registry returns error": {
+			allowedRegistries: []string{"gcr.io/datadoghq"},
+			expectErr:         true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			publisher := newLibraryPublisher(fs, mounter, lm, false, tc.allowedRegistries)
+			targetPath := filepath.Join(t.TempDir(), "target", "library")
+
+			req := &csi.NodePublishVolumeRequest{
+				VolumeId:   "test-volume-allowlist",
+				TargetPath: targetPath,
+				Readonly:   true,
+				VolumeContext: map[string]string{
+					"type":                                "DatadogLibrary",
+					"dd.csi.datadog.com/library.package":  "test-image",
+					"dd.csi.datadog.com/library.registry": registryHost,
+					"dd.csi.datadog.com/library.version":  "v1.0.0",
+				},
+			}
+
+			resp, err := publisher.Publish(req)
+			if tc.expectErr {
+				assert.NotNil(t, resp, "response should be non-nil for metrics")
+				assert.Equal(t, DatadogLibrary, resp.VolumeType)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "not in the allow list")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Equal(t, DatadogLibrary, resp.VolumeType)
+			}
+		})
+	}
+}
+
 func TestLibraryPublisher_Unpublish_Success(t *testing.T) {
 	// Setup local registry with test image
 	localRegistry := testutil.NewLocalRegistry(t)
@@ -228,7 +340,7 @@ func TestLibraryPublisher_Unpublish_Success(t *testing.T) {
 
 	// Create publisher
 	mounter := mount.NewFakeMounter(nil)
-	publisher := newLibraryPublisher(fs, mounter, lm, false)
+	publisher := newLibraryPublisher(fs, mounter, lm, false, nil)
 
 	// First, publish a volume
 	targetPath := filepath.Join(t.TempDir(), "target", "library")

--- a/pkg/driver/publishers/publishers.go
+++ b/pkg/driver/publishers/publishers.go
@@ -45,11 +45,12 @@ func GetPublishers(
 	apmSocketPath, dsdSocketPath, storageBasePath string,
 	libraryManager *librarymanager.LibraryManager,
 	apmEnabled bool,
+	allowedRegistries []string,
 ) Publisher {
 	// Order matters, the first publisher to return a response will stop the chain
 	return newChainPublisher(
 		// SSI publishers (library and injector preload)
-		newLibraryPublisher(fs, mounter, libraryManager, !apmEnabled),
+		newLibraryPublisher(fs, mounter, libraryManager, !apmEnabled, allowedRegistries),
 		newInjectorPreloadPublisher(fs, mounter, storageBasePath, !apmEnabled),
 
 		// New "type" schema publishers

--- a/pkg/driver/publishers/publishers_test.go
+++ b/pkg/driver/publishers/publishers_test.go
@@ -18,7 +18,7 @@ func TestGetPublishers_SkipsSSIPublishersWhenStorageBasePathIsEmpty(t *testing.T
 	fs := afero.Afero{Fs: afero.NewMemMapFs()}
 	mounter := mount.NewFakeMounter(nil)
 
-	publisher := GetPublishers(fs, mounter, "/tmp/apm.sock", "/tmp/dsd.sock", "", nil, true)
+	publisher := GetPublishers(fs, mounter, "/tmp/apm.sock", "/tmp/dsd.sock", "", nil, true, nil)
 
 	t.Run("library volume is ignored", func(t *testing.T) {
 		resp, err := publisher.Publish(&csi.NodePublishVolumeRequest{


### PR DESCRIPTION
## Summary

- Adds `--registry-allow-list` CLI flag (env: `DD_REGISTRY_ALLOW_LIST`) to restrict which OCI registries are permitted for `DatadogLibrary` volumes
- If the list is non-empty, publish requests specifying an unlisted registry are rejected with an error
- Empty list (default) allows all registries — fully backward compatible

## Test plan

- [x] `go test ./pkg/driver/publishers/... ./pkg/librarymanager/...` passes
- [x] `go build ./...` passes
- [ ] Deploy via Helm with `DD_REGISTRY_ALLOW_LIST` set and verify allowed registry succeeds
- [ ] Deploy via Helm with `DD_REGISTRY_ALLOW_LIST` set and verify disallowed registry is rejected
- [ ] Verify empty list (default) continues to allow all registries

Closes INPLAT-881