### PR TITLE
fix(ssi): disable SSI publishers when storage is unwritable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed driver startup to disable SSI publishers when `storageBasePath` is not writable instead of failing initialization
+
 ## [1.2.1] - 2026-02-03
 
 ### Fixed

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -81,7 +81,7 @@ func newDatadogCSIDriver(
 	var err error
 	storageBasePath, err = createStorageDir(fs, storageBasePath)
 	if err != nil {
-		logger.Info("Disabling SSI storage", "storage_base_path", requestedStorageBasePath, "error", err)
+		logger.Warn("Disabling SSI storage", "storage_base_path", requestedStorageBasePath, "error", err)
 		storageBasePath = ""
 	}
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -7,6 +7,8 @@ package driver
 
 import (
 	"fmt"
+	log "log/slog"
+	"strings"
 	"time"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/driver/publishers"
@@ -42,25 +44,57 @@ func (driver *DatadogCSIDriver) Version() string {
 
 // Stop ensures all dependencies are stopped correctly.
 func (driver *DatadogCSIDriver) Stop() error {
+	if driver.libraryManager == nil {
+		return nil
+	}
 	return driver.libraryManager.Stop()
 }
 
-// NewDatadogCSIDriver builds and returns a new Datadog CSI driver
-func NewDatadogCSIDriver(name, apmHostSocketPath, dsdHostSocketPath, storageBasePath, version string, apmEnabled bool) (*DatadogCSIDriver, error) {
-	fs := afero.Afero{Fs: afero.NewOsFs()}
-	mounter := mount.New("")
-
-	// Ensure the storage base path exists
-	if err := fs.MkdirAll(storageBasePath, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create storage base path: %w", err)
+func createStorageDir(fs afero.Afero, storageBasePath string) (string, error) {
+	storageBasePath = strings.TrimSpace(storageBasePath)
+	if storageBasePath == "" {
+		return "", nil
 	}
 
-	lm, err := librarymanager.NewLibraryManager(
-		storageBasePath,
-		librarymanager.WithCleanupStrategy(librarymanager.NewDelayedCleanupStrategy(cleanupDelay)),
-	)
+	if err := fs.MkdirAll(storageBasePath, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create storage base path: %w", err)
+	}
+
+	probeDir, err := afero.TempDir(fs, storageBasePath, ".write-check-*")
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("storage base path is not writable: %w", err)
+	}
+	_ = fs.RemoveAll(probeDir)
+
+	return storageBasePath, nil
+}
+
+func newDatadogCSIDriver(
+	fs afero.Afero,
+	mounter mount.Interface,
+	logger *log.Logger,
+	name, apmHostSocketPath, dsdHostSocketPath, storageBasePath, version string,
+	apmEnabled bool,
+) (*DatadogCSIDriver, error) {
+	requestedStorageBasePath := storageBasePath
+
+	var err error
+	storageBasePath, err = createStorageDir(fs, storageBasePath)
+	if err != nil {
+		logger.Info("Disabling SSI storage", "storage_base_path", requestedStorageBasePath, "error", err)
+		storageBasePath = ""
+	}
+
+	var lm *librarymanager.LibraryManager
+	if storageBasePath != "" {
+		lm, err = librarymanager.NewLibraryManager(
+			storageBasePath,
+			librarymanager.WithFilesystem(fs),
+			librarymanager.WithCleanupStrategy(librarymanager.NewDelayedCleanupStrategy(cleanupDelay)),
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &DatadogCSIDriver{
@@ -72,4 +106,19 @@ func NewDatadogCSIDriver(name, apmHostSocketPath, dsdHostSocketPath, storageBase
 		fs:             fs,
 		mounter:        mounter,
 	}, nil
+}
+
+// NewDatadogCSIDriver builds and returns a new Datadog CSI driver
+func NewDatadogCSIDriver(name, apmHostSocketPath, dsdHostSocketPath, storageBasePath, version string, apmEnabled bool) (*DatadogCSIDriver, error) {
+	return newDatadogCSIDriver(
+		afero.Afero{Fs: afero.NewOsFs()},
+		mount.New(""),
+		log.Default(),
+		name,
+		apmHostSocketPath,
+		dsdHostSocketPath,
+		storageBasePath,
+		version,
+		apmEnabled,
+	)
 }

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -1,0 +1,143 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package driver
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/mount"
+)
+
+func TestCreateStorageDir(t *testing.T) {
+	t.Run("returns empty path without error when input is blank", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+		path, err := createStorageDir(fs, "   ")
+
+		assert.NoError(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("returns error when directory cannot be created", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewReadOnlyFs(afero.NewMemMapFs())}
+
+		path, err := createStorageDir(fs, "/var/datadog")
+
+		assert.Empty(t, path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create storage base path")
+	})
+
+	t.Run("returns error when directory is not writable", func(t *testing.T) {
+		baseFs := afero.NewMemMapFs()
+		err := baseFs.MkdirAll("/var/datadog", 0o755)
+		assert.NoError(t, err)
+
+		fs := afero.Afero{Fs: afero.NewReadOnlyFs(baseFs)}
+
+		path, err := createStorageDir(fs, "/var/datadog")
+
+		assert.Empty(t, path)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns configured path when writable", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+		path, err := createStorageDir(fs, "/var/datadog")
+
+		assert.NoError(t, err)
+		assert.Equal(t, "/var/datadog", path)
+	})
+}
+
+func TestNewDatadogCSIDriver_CreatesLibraryManagerWhenStoragePathIsWritable(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewOsFs()}
+	mounter := mount.NewFakeMounter(nil)
+	storageBasePath := t.TempDir()
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	driver, err := newDatadogCSIDriver(
+		fs,
+		mounter,
+		logger,
+		"test-driver",
+		"/tmp/apm.sock",
+		"/tmp/dsd.sock",
+		storageBasePath,
+		"test-version",
+		true,
+	)
+	require.NoError(t, err)
+
+	assert.NotNil(t, driver.libraryManager)
+	assert.NotContains(t, logs.String(), "Disabling SSI storage")
+}
+
+func TestNewDatadogCSIDriver_DisablesSSIStorageWhenStoragePathIsNotWritable(t *testing.T) {
+	baseFs := afero.NewMemMapFs()
+	err := baseFs.MkdirAll("/var/datadog", 0o755)
+	require.NoError(t, err)
+
+	fs := afero.Afero{Fs: afero.NewReadOnlyFs(baseFs)}
+	mounter := mount.NewFakeMounter(nil)
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	driver, err := newDatadogCSIDriver(
+		fs,
+		mounter,
+		logger,
+		"test-driver",
+		"/tmp/apm.sock",
+		"/tmp/dsd.sock",
+		"/var/datadog",
+		"test-version",
+		true,
+	)
+	require.NoError(t, err)
+
+	assert.Nil(t, driver.libraryManager)
+	assert.Contains(t, logs.String(), "Disabling SSI storage")
+	assert.Contains(t, logs.String(), "storage_base_path=/var/datadog")
+
+	t.Run("library volume is ignored", func(t *testing.T) {
+		resp, err := driver.publisher.Publish(&csi.NodePublishVolumeRequest{
+			VolumeId:   "library-volume",
+			TargetPath: "/target/library",
+			Readonly:   true,
+			VolumeContext: map[string]string{
+				"type": "DatadogLibrary",
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("injector preload volume is ignored", func(t *testing.T) {
+		resp, err := driver.publisher.Publish(&csi.NodePublishVolumeRequest{
+			VolumeId:   "preload-volume",
+			TargetPath: "/target/ld.so.preload",
+			Readonly:   true,
+			VolumeContext: map[string]string{
+				"type": "DatadogInjectorPreload",
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Nil(t, resp)
+	})
+}

--- a/pkg/driver/publishers/publishers.go
+++ b/pkg/driver/publishers/publishers.go
@@ -6,6 +6,8 @@
 package publishers
 
 import (
+	log "log/slog"
+
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/spf13/afero"
@@ -55,6 +57,8 @@ func GetPublishers(
 			newLibraryPublisher(fs, mounter, libraryManager, !apmEnabled),
 			newInjectorPreloadPublisher(fs, mounter, storageBasePath, !apmEnabled),
 		)
+	} else {
+		log.Info("SSI storage publishers are disabled because storageBasePath is empty")
 	}
 
 	publishers = append(

--- a/pkg/driver/publishers/publishers.go
+++ b/pkg/driver/publishers/publishers.go
@@ -46,11 +46,19 @@ func GetPublishers(
 	libraryManager *librarymanager.LibraryManager,
 	apmEnabled bool,
 ) Publisher {
-	// Order matters, the first publisher to return a response will stop the chain
-	return newChainPublisher(
-		// SSI publishers (library and injector preload)
-		newLibraryPublisher(fs, mounter, libraryManager, !apmEnabled),
-		newInjectorPreloadPublisher(fs, mounter, storageBasePath, !apmEnabled),
+	var publishers []Publisher
+
+	// These publishers require writable storage
+	if storageBasePath != "" {
+		publishers = append(publishers,
+			// SSI publishers (library and injector preload)
+			newLibraryPublisher(fs, mounter, libraryManager, !apmEnabled),
+			newInjectorPreloadPublisher(fs, mounter, storageBasePath, !apmEnabled),
+		)
+	}
+
+	publishers = append(
+		publishers,
 
 		// New "type" schema publishers
 		newSocketPublisher(fs, mounter, apmSocketPath, dsdSocketPath),
@@ -63,4 +71,7 @@ func GetPublishers(
 		// Fallback unmount handler for most Unpublish requests
 		newUnmountPublisher(fs, mounter),
 	)
+
+	// Order matters, the first publisher to return a response will stop the chain
+	return newChainPublisher(publishers...)
 }

--- a/pkg/driver/publishers/publishers_test.go
+++ b/pkg/driver/publishers/publishers_test.go
@@ -1,0 +1,50 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package publishers
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/mount"
+)
+
+func TestGetPublishers_SkipsSSIPublishersWhenStorageBasePathIsEmpty(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	mounter := mount.NewFakeMounter(nil)
+
+	publisher := GetPublishers(fs, mounter, "/tmp/apm.sock", "/tmp/dsd.sock", "", nil, true)
+
+	t.Run("library volume is ignored", func(t *testing.T) {
+		resp, err := publisher.Publish(&csi.NodePublishVolumeRequest{
+			VolumeId:   "library-volume",
+			TargetPath: "/target/library",
+			Readonly:   true,
+			VolumeContext: map[string]string{
+				"type": string(DatadogLibrary),
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("injector preload volume is ignored", func(t *testing.T) {
+		resp, err := publisher.Publish(&csi.NodePublishVolumeRequest{
+			VolumeId:   "preload-volume",
+			TargetPath: "/target/ld.so.preload",
+			Readonly:   true,
+			VolumeContext: map[string]string{
+				"type": string(DatadogInjectorPreload),
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Nil(t, resp)
+	})
+}


### PR DESCRIPTION
### What does this PR do?

This PR makes SSI storage optional at runtime when `storageBasePath` cannot be created or written to. Instead of failing driver initialization, the driver now disables storage-dependent SSI publishers and continues to start normally.

It also adds targeted tests for writable and non-writable storage configurations, and updates the changelog accordingly.

### Motivation

Attempt to fix https://github.com/DataDog/datadog-csi-driver/issues/58

The previous behavior caused the driver to fail at startup when `storageBasePath` was present but not writable. In practice, this is more disruptive than necessary because only SSI features depend on that storage path.

This change makes the driver more robust by degrading gracefully: SSI storage is disabled when unusable, while the rest of the driver remains available.

### Additional Notes

A small internal constructor refactor was added to improve testability of the storage setup path and logging behavior.

The `LibraryManager` now also receives the injected filesystem in tests, which keeps constructor behavior consistent.

### Describe your test plan

- Run unit tests:
  - `go test ./pkg/driver/...`

- Verify the following covered cases:
  - `createStorageDir()` returns no error for an empty path
  - `createStorageDir()` returns an error when `MkdirAll` fails
  - `createStorageDir()` returns an error when the storage path is not writable
  - `newDatadogCSIDriver()` creates a `LibraryManager` when storage is writable
  - `newDatadogCSIDriver()` logs SSI storage disablement and skips SSI storage setup when storage is not writable
  - storage-dependent SSI publishers are not registered when `storageBasePath` is empty