### PR TITLE
Add library lifecycle metrics

### DIFF
--- a/.github/workflows/golang-ci-linter.yaml
+++ b/.github/workflows/golang-ci-linter.yaml
@@ -32,6 +32,6 @@ jobs:
       - name: Lint code
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.63.3
+          version: v1.64.8
           only-new-issues: false
           args: ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,9 @@ run:
   timeout: 10m
   modules-download-mode: readonly
   tests: false
-  skip-files:
+
+issues:
+  exclude-files:
     - "testing.go"
     - ".*\\.pb\\.go"
     - ".*\\.gen\\.go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `datadog_csi_driver_library_resolutions_total{result}` (counter): library resolution outcomes (`cache_hit`, `downloaded`, `failed`).
   - `datadog_csi_driver_library_download_duration_seconds{library,registry}` (histogram): time spent downloading a library from the registry.
   - `datadog_csi_driver_library_cleanup_total{status,strategy}` (counter): cleanup attempts for unused libraries (`success`, `failed`, `skipped_in_use`).
+  - `datadog_csi_driver_library_volume_links{library}` (gauge): current number of volumes linked to each library package. Resynced from the database at startup. Series transitioning to zero are kept (not deleted) so dashboards and monitors can observe the "no volumes" state explicitly.
+  - `datadog_csi_driver_libraries_cached{library}` (gauge): number of distinct library versions currently cached on disk for each package. Resynced from the database at startup.
+  - `datadog_csi_driver_libraries_cached_bytes{library}` (gauge): total on-disk size in bytes of the cached library versions for each package. Resynced from the database at startup.
+
+### Changed
+
+- The on-disk library database now persists library metadata (package name, cache state, payload size) in a dedicated `library-metadata` bucket. Existing databases are upgraded transparently at startup: the new bucket is created empty and re-populated when a library is next downloaded. Libraries that were already cached before the upgrade carry no metadata and so report `library="unknown"` in both `datadog_csi_driver_library_volume_links` and `datadog_csi_driver_libraries_cached*` until they are evicted and re-downloaded. No manual action is required.
 
 ## [1.2.2] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `--registry-allow-list` flag (env: `DD_REGISTRY_ALLOW_LIST`) for `DatadogLibrary` volumes. When non-empty, only registries in the list are permitted; requests specifying an unlisted registry are rejected. Empty list (default) allows all registries.
+- New Prometheus metrics for library lifecycle observability:
+  - `datadog_csi_driver_library_resolutions_total{result}` (counter): library resolution outcomes (`cache_hit`, `downloaded`, `failed`).
+  - `datadog_csi_driver_library_download_duration_seconds{library,registry}` (histogram): time spent downloading a library from the registry.
+  - `datadog_csi_driver_library_cleanup_total{status,strategy}` (counter): cleanup attempts for unused libraries (`success`, `failed`, `skipped_in_use`).
 
 ## [1.2.2] - 2026-04-21
 

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -1,3 +1,8 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
 package main
 
 import (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,7 +42,10 @@ func init() {
 	pflag.Parse()
 
 	// Bind flags to viper
-	viper.BindPFlags(pflag.CommandLine)
+	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
+		log.Error("Failed to bind flags to viper", "error", err)
+		os.Exit(1)
+	}
 
 	// Configure env var support
 	// DD_DRIVER_NAME, DD_CSI_ENDPOINT, DD_DSD_HOST_SOCKET_PATH, etc.

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mikelolasagasti/xz v1.0.1 // indirect
 	github.com/minio/minlz v1.0.1 // indirect
@@ -56,7 +57,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
@@ -98,6 +98,7 @@ require (
 require (
 	github.com/google/go-containerregistry v0.20.6
 	github.com/mholt/archives v0.1.5
+	github.com/prometheus/client_model v0.6.1
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	go.etcd.io/bbolt v1.4.3

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Datadog/datadog-csi-driver/pkg/driver/publishers"
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
+	"github.com/Datadog/datadog-csi-driver/pkg/metrics"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/spf13/afero"
@@ -92,6 +93,7 @@ func newDatadogCSIDriver(
 			storageBasePath,
 			librarymanager.WithFilesystem(fs),
 			librarymanager.WithCleanupStrategy(librarymanager.NewDelayedCleanupStrategy(cleanupDelay)),
+			librarymanager.WithEventListener(metrics.NewLibraryListener()),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/driver/publishers/doc.go
+++ b/pkg/driver/publishers/doc.go
@@ -15,7 +15,7 @@ Supported volume types are:
   - DSDSocketDirectory: mounts the directory containing the DogStatsD socket.
   - DatadogSocketsDirectory: mounts the directory containing both sockets.
 
-Deprecated: The legacy `mode`/`path` schema is still supported but deprecated.
-Please migrate to using the `type` schema instead.
+Note: the legacy `mode`/`path` schema is still supported but is considered
+obsolete. Callers should migrate to the `type` schema instead.
 */
 package publishers

--- a/pkg/librarymanager/archive.go
+++ b/pkg/librarymanager/archive.go
@@ -23,6 +23,10 @@ type ArchiveExtractor struct {
 	dst    string      // Absolute path to destination (needed for symlinks, as afero doesn't support them)
 	dstFs  afero.Afero // BasePathFs rooted at destination
 	format archives.Tar
+
+	// bytesExtracted tracks the cumulative size of regular files written
+	// during Extract. Reset on each Extract call.
+	bytesExtracted int64
 }
 
 // NewArchiveExtractor initializes a new archive extractor.
@@ -42,9 +46,14 @@ func NewArchiveExtractor(afs afero.Afero, src string, dst string) (*ArchiveExtra
 }
 
 // Extract will copy files from the configured source directory inside the archive to the desitnation directory outside
-// of the archive through the reader provided.
-func (fp *ArchiveExtractor) Extract(ctx context.Context, reader io.Reader) error {
-	return fp.format.Extract(ctx, reader, fp.processFile)
+// of the archive through the reader provided. Returns the cumulative size of
+// the regular files written; symlinks and directories are not counted.
+func (fp *ArchiveExtractor) Extract(ctx context.Context, reader io.Reader) (int64, error) {
+	fp.bytesExtracted = 0
+	if err := fp.format.Extract(ctx, reader, fp.processFile); err != nil {
+		return 0, err
+	}
+	return fp.bytesExtracted, nil
 }
 
 // processFile is a helper function that is called for every file extracted.
@@ -109,10 +118,11 @@ func (fp *ArchiveExtractor) processFile(ctx context.Context, f archives.FileInfo
 		}
 		defer out.Close()
 
-		_, err = io.Copy(out, in)
+		n, err := io.Copy(out, in)
 		if err != nil {
 			return fmt.Errorf("could not copy destination file: %w", err)
 		}
+		fp.bytesExtracted += n
 
 		return nil
 	default:

--- a/pkg/librarymanager/archive_test.go
+++ b/pkg/librarymanager/archive_test.go
@@ -70,7 +70,7 @@ func TestExtract(t *testing.T) {
 			ctx := context.Background()
 			ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, test.source, tsd.Path(t))
 			require.NoError(t, err, "could not setup extractor")
-			err = ae.Extract(ctx, f)
+			_, err = ae.Extract(ctx, f)
 			require.NoError(t, err, "could not extract archive")
 
 			// List files in the destination by path.
@@ -109,7 +109,8 @@ func TestExtractSymlink(t *testing.T) {
 	ctx := context.Background()
 	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
 	require.NoError(t, err)
-	require.NoError(t, ae.Extract(ctx, f))
+	_, err = ae.Extract(ctx, f)
+	require.NoError(t, err)
 
 	// Verify symlink was created with correct target
 	linkPath := filepath.Join(tsd.Path(t), "latest")
@@ -158,7 +159,7 @@ func TestExtractSymlinkPathTraversal(t *testing.T) {
 			require.NoError(t, err)
 
 			// Extraction should succeed - malicious paths are normalized, not rejected
-			err = ae.Extract(ctx, f)
+			_, err = ae.Extract(ctx, f)
 			require.NoError(t, err)
 
 			// Verify the symlink was created inside the destination (path was normalized)
@@ -199,7 +200,8 @@ func TestExtractSymlinkIdempotent(t *testing.T) {
 	// First extraction
 	f1, err := os.Open(archivePath)
 	require.NoError(t, err)
-	require.NoError(t, ae.Extract(ctx, f1))
+	_, err = ae.Extract(ctx, f1)
+	require.NoError(t, err)
 	f1.Close()
 
 	// Verify symlink exists
@@ -215,7 +217,8 @@ func TestExtractSymlinkIdempotent(t *testing.T) {
 
 	ae2, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
 	require.NoError(t, err)
-	require.NoError(t, ae2.Extract(ctx, f2), "second extraction should succeed when symlink already exists with same target")
+	_, err = ae2.Extract(ctx, f2)
+	require.NoError(t, err, "second extraction should succeed when symlink already exists with same target")
 }
 
 func TestExtractSymlinkNoTarget(t *testing.T) {
@@ -246,7 +249,7 @@ func TestExtractSymlinkNoTarget(t *testing.T) {
 	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
 	require.NoError(t, err)
 
-	err = ae.Extract(ctx, archive)
+	_, err = ae.Extract(ctx, archive)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "has no target")
 }

--- a/pkg/librarymanager/cleanup.go
+++ b/pkg/librarymanager/cleanup.go
@@ -24,6 +24,10 @@ type CleanupStrategy interface {
 
 	// Stop stops the strategy and executes all pending cleanups.
 	Stop()
+
+	// Name returns the short identifier of the strategy (e.g. "immediate", "delayed").
+	// Used for metric labels.
+	Name() string
 }
 
 // ImmediateCleanupStrategy executes cleanup immediately when a library is no longer used.
@@ -44,6 +48,10 @@ func (s *ImmediateCleanupStrategy) ScheduleCleanup(libraryID string, cleanupFunc
 
 func (s *ImmediateCleanupStrategy) Stop() {
 	// No-op: nothing to stop
+}
+
+func (s *ImmediateCleanupStrategy) Name() string {
+	return "immediate"
 }
 
 // DelayedCleanupStrategy waits for a configurable delay before executing cleanup.
@@ -111,6 +119,10 @@ func (s *DelayedCleanupStrategy) ScheduleCleanup(libraryID string, cleanupFunc C
 		timer:       timer,
 		cleanupFunc: cleanupFunc,
 	}
+}
+
+func (s *DelayedCleanupStrategy) Name() string {
+	return "delayed"
 }
 
 func (s *DelayedCleanupStrategy) Stop() {

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sync"
 
 	"go.etcd.io/bbolt"
 )
@@ -22,11 +23,34 @@ const (
 	// VolumeMappingBucket is the bucket to map volumes. Conceptually, the key structure is as follows:
 	//     /volume-mappings/{{ volume_id }}/{{ library_id }}
 	VolumeMappingBucket = "volume-mappings"
+	// LibraryMetadataBucket stores per-library metadata keyed by library ID.
+	// It is the canonical place to look up the package name for a library
+	// and holds the cache-state fields used by the libraries_cached* gauges.
+	//     /library-metadata/{{ library_id }} -> libraryMetadata
+	LibraryMetadataBucket = "library-metadata"
 )
 
+// linkedVolume is the value stored in LibraryMappingBucket[libraryID][volumeID].
 type linkedVolume struct{}
 
+// linkedLibrary is the value stored in VolumeMappingBucket[volumeID][libraryID].
 type linkedLibrary struct{}
+
+// libraryMetadata is the value stored in LibraryMetadataBucket[libraryID]
+type libraryMetadata struct {
+	// Package is the library package name (e.g. dd-lib-java-init).
+	Package string `json:"package,omitempty"`
+	// SizeBytes is the size of the library payload in bytes.
+	SizeBytes int64 `json:"size_bytes,omitempty"`
+	// IsCached is whether the library payload is currently present on disk.
+	IsCached bool `json:"is_cached,omitempty"`
+	// VolumeCount is the number of volumes currently linked to this library.
+	// This is not persisted because bbolt is always the source of truth for the link set itself.
+	// It is rebuilt from LibraryMappingBucket at startup and kept in sync by
+	// LinkVolume / UnlinkVolume. Lets GetVolumeCount answer in O(1) without
+	// re-scanning bbolt on every cleanup attempt.
+	VolumeCount int `json:"-"`
+}
 
 // Database is a wrapper around bbolt with business logic for the library manager.
 //
@@ -39,6 +63,14 @@ type linkedLibrary struct{}
 //
 // The defer tx.Rollback() pattern is safe: if Commit() was already called, Rollback() is a no-op.
 //
+// # In-memory caches
+//
+// Database also maintains in-memory aggregates derived from bbolt so the
+// caller can publish stateful gauges without re-scanning the database on
+// every mutation. The caches are seeded at NewDatabase from the persisted
+// state and kept in sync under cacheMu, which is held for the duration of
+// each mutation so external observers never see bbolt and the caches drift.
+//
 // # External Locking Requirements
 //
 // While individual database transactions are atomic, operations that span multiple transactions
@@ -47,9 +79,30 @@ type linkedLibrary struct{}
 // compound operations on a per-library basis.
 type Database struct {
 	bbolt *bbolt.DB
+
+	// cacheMu protects the in-memory derived state below. It is held for the
+	// full duration of any mutation that touches bbolt so the cache and the
+	// persisted state never disagree as seen from the outside.
+	cacheMu sync.Mutex
+
+	// metadataByLibrary mirrors LibraryMetadataBucket. It holds every library
+	// the database has ever seen (whether currently cached or not), keyed by
+	// libraryID. Used to resolve a library's package in O(1) without going
+	// back to bbolt and as the source for derived aggregates.
+	metadataByLibrary map[string]libraryMetadata
+
+	// volumeLinksByPackage is the per-package count of LibraryMappingBucket
+	// entries. Drives the library_volume_links gauge.
+	volumeLinksByPackage map[string]int
+
+	// cachedCountByPackage and cachedBytesByPackage are the per-package
+	// aggregates for libraries with IsCached=true. They drive the
+	// libraries_cached and libraries_cached_bytes gauges respectively.
+	cachedCountByPackage map[string]int
+	cachedBytesByPackage map[string]int64
 }
 
-// NewDatabase initializes a new database. If a database file exists, it will re-use the existing file. Call close when
+// NewDatabase initializes a new database. If a database file exists, it will re-use the existing file. Call Close when
 // you are done.
 func NewDatabase(basePath string) (*Database, error) {
 	path := filepath.Join(basePath, DatabaseFileName)
@@ -67,15 +120,84 @@ func NewDatabase(basePath string) (*Database, error) {
 		if err != nil {
 			return fmt.Errorf("failed to create bucket %s: %w", VolumeMappingBucket, err)
 		}
+		_, err = tx.CreateBucketIfNotExists([]byte(LibraryMetadataBucket))
+		if err != nil {
+			return fmt.Errorf("failed to create bucket %s: %w", LibraryMetadataBucket, err)
+		}
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not create initial buckets: %w", err)
 	}
 
-	return &Database{
-		bbolt: db,
-	}, nil
+	database := &Database{
+		bbolt:                db,
+		metadataByLibrary:    make(map[string]libraryMetadata),
+		volumeLinksByPackage: make(map[string]int),
+		cachedCountByPackage: make(map[string]int),
+		cachedBytesByPackage: make(map[string]int64),
+	}
+	if err := database.loadCaches(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("could not load library caches: %w", err)
+	}
+	return database, nil
+}
+
+// loadCaches populates the in-memory derived state from bbolt. Called once at
+// startup; subsequent writes keep the cache in sync directly.
+func (db *Database) loadCaches() error {
+	return db.bbolt.View(func(tx *bbolt.Tx) error {
+		metaBkt := tx.Bucket([]byte(LibraryMetadataBucket))
+		if metaBkt == nil {
+			return fmt.Errorf("library metadata bucket does not exist")
+		}
+		mappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
+		if mappingBkt == nil {
+			return fmt.Errorf("library mapping bucket does not exist")
+		}
+
+		if err := metaBkt.ForEach(func(k, v []byte) error {
+			if v == nil {
+				return nil
+			}
+			var meta libraryMetadata
+			if err := json.Unmarshal(v, &meta); err != nil {
+				return fmt.Errorf("could not unmarshal library metadata for %s: %w", string(k), err)
+			}
+			db.metadataByLibrary[string(k)] = meta
+			if meta.IsCached {
+				db.cachedCountByPackage[meta.Package]++
+				db.cachedBytesByPackage[meta.Package] += meta.SizeBytes
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		// Count the volumes linked to each library directly from bbolt and
+		// seed both the per-library VolumeCount (used by GetVolumeCount on the
+		// cleanup path) and the per-package aggregate (used by the gauge).
+		return mappingBkt.ForEach(func(libraryID, v []byte) error {
+			if v != nil {
+				return nil
+			}
+			bkt := mappingBkt.Bucket(libraryID)
+			if bkt == nil {
+				return nil
+			}
+			n := 0
+			bkt.ForEach(func(_, _ []byte) error {
+				n++
+				return nil
+			})
+			meta := db.metadataByLibrary[string(libraryID)]
+			meta.VolumeCount = n
+			db.metadataByLibrary[string(libraryID)] = meta
+			db.volumeLinksByPackage[meta.Package] += n
+			return nil
+		})
+	})
 }
 
 // Close will clean up the database and should be called before exiting.
@@ -83,7 +205,9 @@ func (db *Database) Close() error {
 	return db.bbolt.Close()
 }
 
-// LinkVolume creates a bidrectional mapping between the library and volume.
+// LinkVolume creates a bidirectional mapping between the library and volume.
+// The package the library belongs to must have been registered beforehand by
+// AddLibrary; LinkVolume itself only writes the link buckets.
 func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 	// Validate input.
 	if libraryID == "" {
@@ -124,6 +248,14 @@ func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 		return fmt.Errorf("could not create bucket for volume %s: %w", volumeID, err)
 	}
 
+	// Re-linking the same (library, volume) pair is a no-op: both link
+	// buckets already exist (otherwise the Get would have returned nil) and
+	// the aggregate counters must not move. Bail out before doing any
+	// write so we skip the commit entirely.
+	if libraryBkt.Get([]byte(volumeID)) != nil {
+		return nil
+	}
+
 	// The linked volume is intentially empty at the moment with the expectation that we can add fields at a later
 	// point in time without breaking existing databases.
 	lp, err := json.Marshal(&linkedVolume{})
@@ -150,16 +282,24 @@ func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 		return fmt.Errorf("could not assign volume with id %s: %w", volumeID, err)
 	}
 
+	// Hold cacheMu across Commit and the in-memory aggregate update so
+	// concurrent readers cannot observe the post-commit bbolt state before
+	// the cache catches up.
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+
 	// Commit the transaction.
 	err = tx.Commit()
 	if err != nil {
 		return fmt.Errorf("could not commit transaction: %w", err)
 	}
 
+	db.updateVolumeLinked(libraryID)
 	return nil
 }
 
-// UnlinkVolume removes the link for a given volume.
+// UnlinkVolume removes the link for a given volume. Idempotent: unlinking a
+// non-existent link is a no-op and does not return an error.
 func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 	// Validate input.
 	if libraryID == "" {
@@ -188,9 +328,15 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 		return fmt.Errorf("library mapping bucket does not exist")
 	}
 
+	// Track whether bbolt actually changed so the in-memory counters mirror
+	// the persisted state precisely. bbolt.Delete returns nil for both
+	// "deleted" and "did not exist", hence the explicit lookup.
+	wasRemoved := false
+
 	// Check if the library bucket exists.
 	libraryBucket := libraryMappingBkt.Bucket([]byte(libraryID))
 	if libraryBucket != nil {
+		wasRemoved = libraryBucket.Get([]byte(volumeID)) != nil
 		// Delete the volume for library. Will return nil if the key does not exist and only returns an error if there was an issue.
 		err = libraryBucket.Delete([]byte(volumeID))
 		if err != nil {
@@ -228,50 +374,37 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 		}
 	}
 
+	// Hold cacheMu across Commit and the cache update so any reader that
+	// observes the post-commit bbolt state is forced to wait for the cache
+	// to catch up before it can read it. The bbolt work above ran without
+	// the lock since bbolt already serializes writers.
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+
 	// Commit the transaction.
 	err = tx.Commit()
 	if err != nil {
 		return fmt.Errorf("could not commit transaction: %w", err)
 	}
 
+	if wasRemoved {
+		db.updateVolumeUnlinked(libraryID)
+	}
 	return nil
 }
 
-// GetVolumeCount returns the number of volumes linked to a library.
+// GetVolumeCount returns the number of volumes linked to a library. Reads
+// from the in-memory libraryMetadata.VolumeCount, which is seeded from bbolt
+// at startup and kept in sync by LinkVolume / UnlinkVolume.
 func (db *Database) GetVolumeCount(libraryID string) (int, error) {
 	// Validate input.
 	if libraryID == "" {
 		return 0, fmt.Errorf("library ID cannot be blank")
 	}
 
-	// Start a transaction.
-	tx, err := db.bbolt.Begin(false)
-	if err != nil {
-		return 0, fmt.Errorf("could not start transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
-	root := tx.Bucket([]byte(LibraryMappingBucket))
-	if root == nil {
-		return 0, fmt.Errorf("library mapping bucket does not exist")
-	}
-
-	// Get the bucket for the library. If it doesn't exist, then there are no linked volumes for the library.
-	bkt := root.Bucket([]byte(libraryID))
-	if bkt == nil {
-		return 0, nil
-	}
-
-	// Count the keys in the bucket.
-	count := 0
-	bkt.ForEach(func(k, v []byte) error {
-		count++
-		return nil
-	})
-
-	// Return number of volumes linked to the bucket.
-	return count, nil
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	return db.metadataByLibrary[libraryID].VolumeCount, nil
 }
 
 // GetLibraryForVolume returns the library mapped to a volume. A volume should only ever have one library mapped to it.
@@ -307,4 +440,211 @@ func (db *Database) GetLibraryForVolume(volumeID string) (string, error) {
 	}
 
 	return string(key), nil
+}
+
+// GetPackageForLibrary returns the package name persisted for a library, or an
+// empty string if the library is not tracked. Reads from the in-memory cache.
+func (db *Database) GetPackageForLibrary(libraryID string) (string, error) {
+	if libraryID == "" {
+		return "", fmt.Errorf("library ID cannot be blank")
+	}
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	return db.metadataByLibrary[libraryID].Package, nil
+}
+
+// AddLibrary registers a library in the metadata bucket and marks it as
+// cached on disk. It is the canonical writer for the library metadata
+// entry: the package name, payload size and cache flag are all set here.
+// Intended to be called once per successful download, before LinkVolume.
+// Re-calling AddLibrary on an already-cached library updates the size
+// (used as a defensive path for any future in-place re-cache).
+//
+// Callers that need to publish the per-package aggregate after the mutation
+// should read it via PackageCacheStats.
+func (db *Database) AddLibrary(libraryID string, packageName string, sizeBytes int64) error {
+	if libraryID == "" {
+		return fmt.Errorf("library ID cannot be blank")
+	}
+	if sizeBytes < 0 {
+		return fmt.Errorf("sizeBytes must be non-negative, got %d", sizeBytes)
+	}
+
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+
+	// Build the bbolt payload from the current cache state (VolumeCount is
+	// in-memory only and stripped by the json tags).
+	next := db.metadataByLibrary[libraryID]
+	next.Package = packageName
+	next.SizeBytes = sizeBytes
+	next.IsCached = true
+
+	if err := db.bbolt.Update(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+		if bkt == nil {
+			return fmt.Errorf("library metadata bucket does not exist")
+		}
+		return writeLibraryMetadata(bkt, []byte(libraryID), next)
+	}); err != nil {
+		return err
+	}
+
+	db.updateLibraryCached(libraryID, packageName, sizeBytes)
+	return nil
+}
+
+// RemoveLibrary drops a library's metadata entry, mirroring an eviction
+// from the on-disk store. Intended to be called by the cleanup path once
+// the library has no remaining volume links and its payload has been
+// deleted from disk. Idempotent: if the library was never added (unknown
+// or already removed), the call is a no-op.
+//
+// Callers that need to publish the per-package aggregate after the mutation
+// should read it via PackageCacheStats.
+func (db *Database) RemoveLibrary(libraryID string) error {
+	if libraryID == "" {
+		return fmt.Errorf("library ID cannot be blank")
+	}
+
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+
+	previous, known := db.metadataByLibrary[libraryID]
+	if !known || !previous.IsCached {
+		// Skip the bbolt write: there is no observable state to flip and
+		// writing here would materialize a spurious metadata entry for an
+		// unknown libraryID.
+		return nil
+	}
+
+	if err := db.bbolt.Update(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+		if bkt == nil {
+			return fmt.Errorf("library metadata bucket does not exist")
+		}
+		return bkt.Delete([]byte(libraryID))
+	}); err != nil {
+		return err
+	}
+
+	db.updateLibraryEvicted(libraryID)
+	return nil
+}
+
+// PackageCacheStats returns the current per-package cached library count and
+// byte total. Reads from the in-memory aggregate and returns zero values for
+// unknown packages.
+func (db *Database) PackageCacheStats(pkg string) (count int, bytes int64) {
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	return db.cachedCountByPackage[pkg], db.cachedBytesByPackage[pkg]
+}
+
+// VolumeLinkCount returns the current number of volumes linked to any
+// library belonging to the given package. Reads from the in-memory aggregate
+// and returns 0 for unknown packages.
+func (db *Database) VolumeLinkCount(pkg string) int {
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	return db.volumeLinksByPackage[pkg]
+}
+
+// Snapshot returns copies of the per-package aggregates: volume link counts,
+// cached library counts and cached library bytes. Used by observers that want
+// to resync without going through bbolt themselves (e.g. metrics listeners on
+// startup). The three maps are captured under a single lock so they reflect a
+// consistent point-in-time view.
+func (db *Database) Snapshot() (volumeLinks map[string]int, cachedCounts map[string]int, cachedBytes map[string]int64) {
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	volumeLinks = make(map[string]int, len(db.volumeLinksByPackage))
+	for k, v := range db.volumeLinksByPackage {
+		volumeLinks[k] = v
+	}
+	cachedCounts = make(map[string]int, len(db.cachedCountByPackage))
+	for k, v := range db.cachedCountByPackage {
+		cachedCounts[k] = v
+	}
+	cachedBytes = make(map[string]int64, len(db.cachedBytesByPackage))
+	for k, v := range db.cachedBytesByPackage {
+		cachedBytes[k] = v
+	}
+	return volumeLinks, cachedCounts, cachedBytes
+}
+
+// updateVolumeLinked mirrors a new (library, volume) link in the in-memory
+// caches. The caller must hold cacheMu. The per-package aggregate is keyed
+// on whatever Package was already registered for this library (empty if
+// AddLibrary has not run yet, e.g. upgrade from a release that had
+// no metadata bucket).
+func (db *Database) updateVolumeLinked(libraryID string) {
+	meta := db.metadataByLibrary[libraryID]
+	meta.VolumeCount++
+	db.metadataByLibrary[libraryID] = meta
+	db.volumeLinksByPackage[meta.Package]++
+}
+
+// updateVolumeUnlinked mirrors a removed (library, volume) link in the
+// in-memory caches. Both counters are defensively clamped at zero so any
+// drift between bbolt and the cache cannot surface as a negative gauge.
+// The caller must hold cacheMu.
+func (db *Database) updateVolumeUnlinked(libraryID string) {
+	meta := db.metadataByLibrary[libraryID]
+	if meta.VolumeCount > 0 {
+		meta.VolumeCount--
+		db.metadataByLibrary[libraryID] = meta
+	}
+	if db.volumeLinksByPackage[meta.Package] > 0 {
+		db.volumeLinksByPackage[meta.Package]--
+	}
+}
+
+// updateLibraryCached mirrors a successful library cache (download) in the
+// in-memory caches and adjusts the per-package aggregates. A re-cache of an
+// already-cached library only adjusts the byte delta, leaving the count
+// alone. The caller must hold cacheMu.
+func (db *Database) updateLibraryCached(libraryID, packageName string, sizeBytes int64) {
+	previous := db.metadataByLibrary[libraryID]
+	next := previous
+	next.Package = packageName
+	next.SizeBytes = sizeBytes
+	next.IsCached = true
+	db.metadataByLibrary[libraryID] = next
+
+	switch {
+	case !previous.IsCached:
+		db.cachedCountByPackage[next.Package]++
+		db.cachedBytesByPackage[next.Package] += next.SizeBytes
+	case previous.IsCached && previous.Package == next.Package:
+		db.cachedBytesByPackage[next.Package] += next.SizeBytes - previous.SizeBytes
+	}
+}
+
+// updateLibraryEvicted mirrors a library eviction in the in-memory caches:
+// the metadata entry is dropped and the per-package aggregates are
+// decremented (clamped at zero). The caller must hold cacheMu and have
+// verified that the library was actually cached.
+func (db *Database) updateLibraryEvicted(libraryID string) {
+	previous := db.metadataByLibrary[libraryID]
+	delete(db.metadataByLibrary, libraryID)
+	if db.cachedCountByPackage[previous.Package] > 0 {
+		db.cachedCountByPackage[previous.Package]--
+	}
+	db.cachedBytesByPackage[previous.Package] -= previous.SizeBytes
+	if db.cachedBytesByPackage[previous.Package] < 0 {
+		db.cachedBytesByPackage[previous.Package] = 0
+	}
+}
+
+// writeLibraryMetadata serializes and stores the metadata in the given bucket.
+func writeLibraryMetadata(bkt *bbolt.Bucket, libraryID []byte, meta libraryMetadata) error {
+	encoded, err := json.Marshal(&meta)
+	if err != nil {
+		return fmt.Errorf("could not marshal library metadata: %w", err)
+	}
+	if err := bkt.Put(libraryID, encoded); err != nil {
+		return fmt.Errorf("could not write library metadata: %w", err)
+	}
+	return nil
 }

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -282,9 +282,8 @@ func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 		return fmt.Errorf("could not assign volume with id %s: %w", volumeID, err)
 	}
 
-	// Hold cacheMu across Commit and the in-memory aggregate update so
-	// concurrent readers cannot observe the post-commit bbolt state before
-	// the cache catches up.
+	// Hold cacheMu across Commit and the cache update so readers never
+	// observe bbolt and the in-memory aggregates disagree.
 	db.cacheMu.Lock()
 	defer db.cacheMu.Unlock()
 
@@ -374,10 +373,7 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 		}
 	}
 
-	// Hold cacheMu across Commit and the cache update so any reader that
-	// observes the post-commit bbolt state is forced to wait for the cache
-	// to catch up before it can read it. The bbolt work above ran without
-	// the lock since bbolt already serializes writers.
+	// See LinkVolume for the cacheMu/Commit ordering rationale.
 	db.cacheMu.Lock()
 	defer db.cacheMu.Unlock()
 
@@ -550,27 +546,28 @@ func (db *Database) VolumeLinkCount(pkg string) int {
 	return db.volumeLinksByPackage[pkg]
 }
 
-// Snapshot returns copies of the per-package aggregates: volume link counts,
-// cached library counts and cached library bytes. Used by observers that want
-// to resync without going through bbolt themselves (e.g. metrics listeners on
-// startup). The three maps are captured under a single lock so they reflect a
-// consistent point-in-time view.
-func (db *Database) Snapshot() (volumeLinks map[string]int, cachedCounts map[string]int, cachedBytes map[string]int64) {
+// Snapshot returns a deep copy of the per-package aggregates captured under a
+// single lock so the three maps reflect a consistent point-in-time view.
+// Used by observers that want to resync without going through bbolt
+// themselves (e.g. metrics listeners on startup).
+func (db *Database) Snapshot() Snapshot {
 	db.cacheMu.Lock()
 	defer db.cacheMu.Unlock()
-	volumeLinks = make(map[string]int, len(db.volumeLinksByPackage))
+	s := Snapshot{
+		VolumeLinksByPackage: make(map[string]int, len(db.volumeLinksByPackage)),
+		CachedCountByPackage: make(map[string]int, len(db.cachedCountByPackage)),
+		CachedBytesByPackage: make(map[string]int64, len(db.cachedBytesByPackage)),
+	}
 	for k, v := range db.volumeLinksByPackage {
-		volumeLinks[k] = v
+		s.VolumeLinksByPackage[k] = v
 	}
-	cachedCounts = make(map[string]int, len(db.cachedCountByPackage))
 	for k, v := range db.cachedCountByPackage {
-		cachedCounts[k] = v
+		s.CachedCountByPackage[k] = v
 	}
-	cachedBytes = make(map[string]int64, len(db.cachedBytesByPackage))
 	for k, v := range db.cachedBytesByPackage {
-		cachedBytes[k] = v
+		s.CachedBytesByPackage[k] = v
 	}
-	return volumeLinks, cachedCounts, cachedBytes
+	return s
 }
 
 // updateVolumeLinked mirrors a new (library, volume) link in the in-memory

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -187,10 +187,12 @@ func (db *Database) loadCaches() error {
 				return nil
 			}
 			n := 0
-			bkt.ForEach(func(_, _ []byte) error {
+			if err := bkt.ForEach(func(_, _ []byte) error {
 				n++
 				return nil
-			})
+			}); err != nil {
+				return fmt.Errorf("could not iterate library bucket %s: %w", libraryID, err)
+			}
 			meta := db.metadataByLibrary[string(libraryID)]
 			meta.VolumeCount = n
 			db.metadataByLibrary[string(libraryID)] = meta
@@ -222,7 +224,7 @@ func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("could not start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
 	libraryMappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
@@ -313,7 +315,7 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("could not start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
 	libraryMappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
@@ -415,7 +417,7 @@ func (db *Database) GetLibraryForVolume(volumeID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Get the bucket for volume mappings. If it doesn't exist, we have a system level issue.
 	root := tx.Bucket([]byte(VolumeMappingBucket))

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -305,7 +305,7 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 		return fmt.Errorf("library ID cannot be blank")
 	}
 	if volumeID == "" {
-		return fmt.Errorf(" volume ID cannot be blank")
+		return fmt.Errorf("volume ID cannot be blank")
 	}
 
 	// Start a transaction.

--- a/pkg/librarymanager/db_internal_test.go
+++ b/pkg/librarymanager/db_internal_test.go
@@ -108,3 +108,50 @@ func mustInternalLink(t *testing.T, db *Database, libraryID, volumeID string) {
 	t.Helper()
 	require.NoError(t, db.LinkVolume(libraryID, volumeID))
 }
+
+// TestNewDatabaseFailsOnCorruptedMetadata writes garbage into the metadata
+// bucket and verifies NewDatabase surfaces the unmarshal failure instead of
+// silently swallowing it. A corrupted metadata entry is the only realistic
+// way loadCaches can fail on a freshly-opened file.
+func TestNewDatabaseFailsOnCorruptedMetadata(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	dir := tsd.Path(t)
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+
+	// Inject invalid JSON under a libraryID key.
+	require.NoError(t, db.bbolt.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket([]byte(LibraryMetadataBucket)).Put([]byte("lib-broken"), []byte("not-json"))
+	}))
+	require.NoError(t, db.Close())
+
+	// Reopening must fail at the loadCaches step.
+	_, err = NewDatabase(dir)
+	require.Error(t, err, "NewDatabase must reject a database with unparseable metadata")
+	require.Contains(t, err.Error(), "lib-broken")
+}
+
+// TestGetLibraryForVolumeWithEmptyBucket exercises the defensive
+// "bucket exists but holds no entries" branch in GetLibraryForVolume.
+// Production code does not leave behind empty volume buckets, but the
+// branch protects against future drift or partially-applied transactions.
+func TestGetLibraryForVolumeWithEmptyBucket(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create an empty volume bucket directly without going through LinkVolume.
+	require.NoError(t, db.bbolt.Update(func(tx *bbolt.Tx) error {
+		_, err := tx.Bucket([]byte(VolumeMappingBucket)).CreateBucket([]byte("vol-empty"))
+		return err
+	}))
+
+	lib, err := db.GetLibraryForVolume("vol-empty")
+	require.NoError(t, err, "an empty volume bucket must not surface as an error")
+	require.Empty(t, lib, "an empty volume bucket must resolve to no library")
+}

--- a/pkg/librarymanager/db_internal_test.go
+++ b/pkg/librarymanager/db_internal_test.go
@@ -63,8 +63,7 @@ func TestNewDatabaseRecoversFromMissingMetadataBucket(t *testing.T) {
 	// Pre-migration links are surfaced under an empty package label until
 	// the library is re-registered. Tagging the gauge series with "" lets
 	// observers remap it to "unknown" at publish time.
-	volumeLinks, _, _ := db2.Snapshot()
-	require.Equal(t, map[string]int{"": 2}, volumeLinks,
+	require.Equal(t, map[string]int{"": 2}, db2.Snapshot().VolumeLinksByPackage,
 		"links carried over from the old layout must be counted under an empty package")
 
 	// Re-registering the library (e.g. at the next download) sets the
@@ -75,8 +74,7 @@ func TestNewDatabaseRecoversFromMissingMetadataBucket(t *testing.T) {
 	pkg, err = db2.GetPackageForLibrary("lib-java")
 	require.NoError(t, err)
 	require.Equal(t, "dd-lib-java-init", pkg)
-	volumeLinks, _, _ = db2.Snapshot()
-	require.Equal(t, map[string]int{"": 2, "dd-lib-java-init": 1}, volumeLinks,
+	require.Equal(t, map[string]int{"": 2, "dd-lib-java-init": 1}, db2.Snapshot().VolumeLinksByPackage,
 		"only the post-migration link is moved to the package aggregate")
 }
 

--- a/pkg/librarymanager/db_internal_test.go
+++ b/pkg/librarymanager/db_internal_test.go
@@ -1,0 +1,112 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package librarymanager
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+// TestNewDatabaseRecoversFromMissingMetadataBucket simulates a database
+// written by an older driver version (links present, no LibraryMetadataBucket
+// at all). NewDatabase must recreate the bucket without dropping existing
+// volume mappings; the per-library package is not recovered until the next
+// AddLibrary runs (typically at the next download for that library).
+func TestNewDatabaseRecoversFromMissingMetadataBucket(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	dir := tsd.Path(t)
+
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	// The pre-migration driver had no metadata bucket, so links are created
+	// without any associated package.
+	mustInternalLink(t, db, "lib-java", "vol-1")
+	mustInternalLink(t, db, "lib-java", "vol-2")
+
+	// Strip the LibraryMetadataBucket entirely to mimic what an older driver
+	// would have produced.
+	require.NoError(t, db.bbolt.Update(func(tx *bbolt.Tx) error {
+		return tx.DeleteBucket([]byte(LibraryMetadataBucket))
+	}))
+	require.NoError(t, db.Close())
+
+	// Reopen: NewDatabase must recreate the bucket. Existing links survive,
+	// even though their package is now unknown until AddLibrary runs.
+	db2, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db2.Close()
+
+	lib, err := db2.GetLibraryForVolume("vol-1")
+	require.NoError(t, err)
+	require.Equal(t, "lib-java", lib, "existing mappings must be preserved across the migration")
+
+	// The per-library volume count must be reseeded from bbolt at startup so
+	// the cleanup path never wrongly removes a library that still has volumes
+	// linked to it.
+	count, err := db2.GetVolumeCount("lib-java")
+	require.NoError(t, err)
+	require.Equal(t, 2, count, "GetVolumeCount must be reseeded from bbolt across restarts")
+
+	pkg, err := db2.GetPackageForLibrary("lib-java")
+	require.NoError(t, err)
+	require.Empty(t, pkg, "package is not recovered until the next AddLibrary after migration")
+
+	// Pre-migration links are surfaced under an empty package label until
+	// the library is re-registered. Tagging the gauge series with "" lets
+	// observers remap it to "unknown" at publish time.
+	volumeLinks, _, _ := db2.Snapshot()
+	require.Equal(t, map[string]int{"": 2}, volumeLinks,
+		"links carried over from the old layout must be counted under an empty package")
+
+	// Re-registering the library (e.g. at the next download) sets the
+	// package label going forward; previously-aggregated link counts stay
+	// under "" until they are recycled (unlink + re-link).
+	require.NoError(t, db2.AddLibrary("lib-java", "dd-lib-java-init", 0))
+	mustInternalLink(t, db2, "lib-java", "vol-3")
+	pkg, err = db2.GetPackageForLibrary("lib-java")
+	require.NoError(t, err)
+	require.Equal(t, "dd-lib-java-init", pkg)
+	volumeLinks, _, _ = db2.Snapshot()
+	require.Equal(t, map[string]int{"": 2, "dd-lib-java-init": 1}, volumeLinks,
+		"only the post-migration link is moved to the package aggregate")
+}
+
+// TestDatabaseFileEnsureSchema checks that DatabaseFileName is created under
+// the provided directory and the LibraryMetadataBucket is present after a
+// fresh open. This is a small sanity check that doubles as documentation of
+// where the database file lands.
+func TestDatabaseFileEnsureSchema(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	dir := tsd.Path(t)
+	db, err := NewDatabase(dir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// The DB file exists at the expected location.
+	_, err = db.bbolt.Path(), error(nil)
+	require.Equal(t, filepath.Join(dir, DatabaseFileName), db.bbolt.Path())
+
+	// All three buckets are present right after a fresh open.
+	require.NoError(t, db.bbolt.View(func(tx *bbolt.Tx) error {
+		for _, name := range []string{LibraryMappingBucket, VolumeMappingBucket, LibraryMetadataBucket} {
+			require.NotNil(t, tx.Bucket([]byte(name)), "bucket %s must exist after NewDatabase", name)
+		}
+		return nil
+	}))
+}
+
+func mustInternalLink(t *testing.T, db *Database, libraryID, volumeID string) {
+	t.Helper()
+	require.NoError(t, db.LinkVolume(libraryID, volumeID))
+}

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -36,12 +36,17 @@ func TestDatabase(t *testing.T) {
 	require.Equal(t, 0, count, "there should be no volumes linked")
 
 	// Ensure that an unlink does not produce an error if it has not been linked.
-	err = db.UnlinkVolume(libraryID, volumeID)
-	require.NoError(t, err)
+	require.NoError(t, db.UnlinkVolume(libraryID, volumeID))
+
+	// Register the library metadata (mirrors a successful download in
+	// production: AddLibrary is the canonical writer for the
+	// per-library Package label).
+	pkg := "dd-lib-java-init"
+	require.NoError(t, db.AddLibrary(libraryID, pkg, 0))
 
 	// Ensure a linked volume is linked.
-	err = db.LinkVolume(libraryID, volumeID)
-	require.NoError(t, err)
+	require.NoError(t, db.LinkVolume(libraryID, volumeID))
+	require.Equal(t, 1, db.VolumeLinkCount(pkg), "first link must take the package count to 1")
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
 	require.Equal(t, libraryID, lib, "there should be a library linked")
@@ -49,44 +54,250 @@ func TestDatabase(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, count, "there should be one volume linked")
 
-	// Ensure a second call to link the same volume does nothing
-	err = db.LinkVolume(libraryID, volumeID)
-	require.NoError(t, err)
-	lib, err = db.GetLibraryForVolume(volumeID)
-	require.NoError(t, err)
-	require.Equal(t, libraryID, lib, "there should be a library linked")
+	// A second call to link the same (library, volume) must be idempotent
+	// for the aggregate counters.
+	require.NoError(t, db.LinkVolume(libraryID, volumeID))
+	require.Equal(t, 1, db.VolumeLinkCount(pkg), "idempotent re-link must not move the package count")
 	count, err = db.GetVolumeCount(libraryID)
 	require.NoError(t, err)
 	require.Equal(t, 1, count, "there should still be one volume linked")
 
-	// Ensure a second linked volume shows both.
+	// Linking a second volume to the same library bumps the package count.
 	secondVolumeID := "test-volume-id-two"
-	err = db.LinkVolume(libraryID, secondVolumeID)
-	require.NoError(t, err)
-	lib, err = db.GetLibraryForVolume(volumeID)
-	require.NoError(t, err)
-	require.Equal(t, libraryID, lib, "there should be a library linked")
+	require.NoError(t, db.LinkVolume(libraryID, secondVolumeID))
+	require.Equal(t, 2, db.VolumeLinkCount(pkg))
 	count, err = db.GetVolumeCount(libraryID)
 	require.NoError(t, err)
 	require.Equal(t, 2, count, "there should be two volumes linked")
 
-	// Ensure an unlinked volume only has one volume linked.
-	err = db.UnlinkVolume(libraryID, secondVolumeID)
-	require.NoError(t, err)
-	lib, err = db.GetLibraryForVolume(volumeID)
-	require.NoError(t, err)
-	require.Equal(t, libraryID, lib, "there should be a library linked")
+	// Unlinking one volume drops the count by one.
+	require.NoError(t, db.UnlinkVolume(libraryID, secondVolumeID))
+	require.Equal(t, 1, db.VolumeLinkCount(pkg))
 	count, err = db.GetVolumeCount(libraryID)
 	require.NoError(t, err)
 	require.Equal(t, 1, count, "there should be one volume linked")
 
-	// Ensure all unlinks completely zeros out the count.
-	err = db.UnlinkVolume(libraryID, volumeID)
-	require.NoError(t, err)
+	// Unlinking the last volume zeros the package count but keeps the
+	// metadata entry around so the package can still be resolved.
+	require.NoError(t, db.UnlinkVolume(libraryID, volumeID))
+	require.Equal(t, 0, db.VolumeLinkCount(pkg))
 	count, err = db.GetVolumeCount(libraryID)
 	require.NoError(t, err)
 	require.Equal(t, 0, count, "there should be no volumes linked")
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
 	require.Empty(t, lib, "there should be no libs linked")
+
+	// A second unlink of the same (libraryID, volumeID) is a no-op.
+	require.NoError(t, db.UnlinkVolume(libraryID, volumeID))
+	require.Equal(t, 0, db.VolumeLinkCount(pkg), "repeated unlink must not move the package count")
+}
+
+func TestDatabasePackageTracking(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Two libraries, three packages worth of links. The metadata must be
+	// registered (AddLibrary) before any LinkVolume to ensure the
+	// per-package aggregate uses the right label.
+	require.NoError(t, db.AddLibrary("lib-java", "dd-lib-java-init", 0))
+	require.NoError(t, db.AddLibrary("lib-php", "dd-lib-php-init", 0))
+	mustLink(t, db, "lib-java", "vol-1")
+	mustLink(t, db, "lib-java", "vol-2")
+	mustLink(t, db, "lib-php", "vol-3")
+
+	volumeLinks, _, _ := db.Snapshot()
+	require.Equal(t, map[string]int{
+		"dd-lib-java-init": 2,
+		"dd-lib-php-init":  1,
+	}, volumeLinks)
+
+	pkg, err := db.GetPackageForLibrary("lib-java")
+	require.NoError(t, err)
+	require.Equal(t, "dd-lib-java-init", pkg)
+
+	pkg, err = db.GetPackageForLibrary("lib-php")
+	require.NoError(t, err)
+	require.Equal(t, "dd-lib-php-init", pkg)
+
+	// Unknown library yields an empty package and no error.
+	pkg, err = db.GetPackageForLibrary("lib-unknown")
+	require.NoError(t, err)
+	require.Empty(t, pkg)
+
+	// Unlinking the last php volume drops the package count to zero. The
+	// entry is kept in the snapshot at zero rather than removed: dashboards
+	// can then observe the "no volumes" transition explicitly.
+	require.NoError(t, db.UnlinkVolume("lib-php", "vol-3"))
+	volumeLinks, _, _ = db.Snapshot()
+	require.Equal(t, map[string]int{
+		"dd-lib-java-init": 2,
+		"dd-lib-php-init":  0,
+	}, volumeLinks)
+}
+
+func TestDatabaseLinkWithoutRegistrationFallsBackToEmptyPackage(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Simulate the upgrade-from-1.2.2 case: a library is linked before any
+	// AddLibrary has run, so no Package is registered.
+	mustLink(t, db, "lib-legacy", "vol-legacy")
+
+	volumeLinks, _, _ := db.Snapshot()
+	require.Equal(t, map[string]int{"": 1}, volumeLinks, "unregistered libraries surface under the empty key")
+
+	pkg, err := db.GetPackageForLibrary("lib-legacy")
+	require.NoError(t, err)
+	require.Empty(t, pkg)
+}
+
+func TestDatabaseLibraryMetadataCacheLifecycle(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Linking a volume without prior AddLibrary is the legacy /
+	// upgrade-from-pre-feature scenario: no Package or cache state is
+	// registered.
+	mustLink(t, db, "lib-java", "vol-1")
+	_, counts, bytes := db.Snapshot()
+	require.Empty(t, counts)
+	require.Empty(t, bytes)
+
+	// First AddLibrary registers the package and publishes the
+	// library at its measured size.
+	require.NoError(t, db.AddLibrary("lib-java", "dd-lib-java-init", 12_345))
+	count, byteTotal := db.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 1, count)
+	require.Equal(t, int64(12_345), byteTotal)
+
+	_, counts, bytes = db.Snapshot()
+	require.Equal(t, map[string]int{"dd-lib-java-init": 1}, counts)
+	require.Equal(t, map[string]int64{"dd-lib-java-init": 12_345}, bytes)
+
+	// Re-caching the same library replaces the size, not the count. This is
+	// a defensive path for any future in-place re-cache; the package totals
+	// must track the size delta.
+	require.NoError(t, db.AddLibrary("lib-java", "dd-lib-java-init", 99_999))
+	count, byteTotal = db.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 1, count, "re-caching must not bump the package count")
+	require.Equal(t, int64(99_999), byteTotal)
+
+	_, _, bytes = db.Snapshot()
+	require.Equal(t, map[string]int64{"dd-lib-java-init": 99_999}, bytes)
+
+	// RemoveLibrary drops the cache state and wipes the metadata entry.
+	require.NoError(t, db.RemoveLibrary("lib-java"))
+	count, byteTotal = db.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 0, count)
+	require.Equal(t, int64(0), byteTotal)
+
+	pkg, err := db.GetPackageForLibrary("lib-java")
+	require.NoError(t, err)
+	require.Empty(t, pkg, "metadata entry must be gone after eviction")
+}
+
+func TestDatabaseRemoveLibraryUnknownIsNoop(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Evicting a library that was never marked cached must not change the
+	// snapshot and must not materialize a metadata entry for it.
+	require.NoError(t, db.RemoveLibrary("lib-unknown"))
+
+	_, counts, bytes := db.Snapshot()
+	require.Empty(t, counts)
+	require.Empty(t, bytes)
+
+	pkg, err := db.GetPackageForLibrary("lib-unknown")
+	require.NoError(t, err)
+	require.Empty(t, pkg, "RemoveLibrary must not materialize an entry for an unknown library")
+}
+
+func TestDatabaseAggregatesAcrossMultipleVersionsOfTheSamePackage(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Two distinct PHP library versions share the same package. Each version
+	// has its own library_id (e.g. a digest of the image) but contributes to
+	// the same per-package gauges.
+	const (
+		phpPackage = "dd-lib-php-init"
+		php81      = "lib-php-8.1-hash"
+		php82      = "lib-php-8.2-hash"
+	)
+
+	// Register each version, then link its volumes. Order mirrors production:
+	// AddLibrary at download time, then LinkVolume for each mount.
+	require.NoError(t, db.AddLibrary(php81, phpPackage, 5_000_000))
+	mustLink(t, db, php81, "vol-a")
+	mustLink(t, db, php81, "vol-b")
+	require.NoError(t, db.AddLibrary(php82, phpPackage, 5_500_000))
+	mustLink(t, db, php82, "vol-c")
+
+	volumeLinks, _, _ := db.Snapshot()
+	require.Equal(t, map[string]int{phpPackage: 3}, volumeLinks,
+		"volume links must be summed across every version of the same package")
+
+	count, bytesTotal := db.PackageCacheStats(phpPackage)
+	require.Equal(t, 2, count, "the package must count both cached versions")
+	require.Equal(t, int64(10_500_000), bytesTotal, "package bytes must sum every cached version")
+
+	_, counts, bytes := db.Snapshot()
+	require.Equal(t, map[string]int{phpPackage: 2}, counts)
+	require.Equal(t, map[string]int64{phpPackage: 10_500_000}, bytes)
+
+	// Unlinking the volumes of one version drops the link count for the
+	// package by one each; the package label stays the same.
+	require.NoError(t, db.UnlinkVolume(php81, "vol-a"))
+	require.NoError(t, db.UnlinkVolume(php81, "vol-b"))
+	volumeLinks, _, _ = db.Snapshot()
+	require.Equal(t, map[string]int{phpPackage: 1}, volumeLinks)
+
+	// Evicting one version drops the package count by one and removes only
+	// the corresponding bytes; the other version is untouched. In practice
+	// eviction is only ever called after the last volume of a library has
+	// been unlinked, hence the ordering here.
+	require.NoError(t, db.RemoveLibrary(php81))
+	count, bytesTotal = db.PackageCacheStats(phpPackage)
+	require.Equal(t, 1, count, "evicting one version must not affect the others")
+	require.Equal(t, int64(5_500_000), bytesTotal)
+}
+
+func TestDatabaseAddLibraryValidatesInputs(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.Error(t, db.AddLibrary("", "pkg", 1), "empty libraryID must be rejected")
+	require.Error(t, db.AddLibrary("lib", "pkg", -1), "negative size must be rejected")
+}
+
+// mustLink is a tiny test helper that asserts LinkVolume succeeded.
+func mustLink(t *testing.T, db *librarymanager.Database, libraryID, volumeID string) {
+	t.Helper()
+	require.NoError(t, db.LinkVolume(libraryID, volumeID))
 }

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -289,6 +289,32 @@ func TestDatabaseAddLibraryValidatesInputs(t *testing.T) {
 	require.Error(t, db.AddLibrary("lib", "pkg", -1), "negative size must be rejected")
 }
 
+// TestDatabaseValidatesBlankInputs asserts every public method rejects empty
+// IDs up front so a bug at the caller never silently corrupts the database
+// (e.g. linking under an empty libraryID would aggregate orphan series).
+func TestDatabaseValidatesBlankInputs(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.Error(t, db.LinkVolume("", "vol"), "blank libraryID must be rejected")
+	require.Error(t, db.LinkVolume("lib", ""), "blank volumeID must be rejected")
+	require.Error(t, db.UnlinkVolume("", "vol"), "blank libraryID must be rejected")
+	require.Error(t, db.UnlinkVolume("lib", ""), "blank volumeID must be rejected")
+
+	_, err = db.GetVolumeCount("")
+	require.Error(t, err, "blank libraryID must be rejected")
+	_, err = db.GetLibraryForVolume("")
+	require.Error(t, err, "blank volumeID must be rejected")
+	_, err = db.GetPackageForLibrary("")
+	require.Error(t, err, "blank libraryID must be rejected")
+
+	require.Error(t, db.RemoveLibrary(""), "blank libraryID must be rejected")
+}
+
 // mustLink is a tiny test helper that asserts LinkVolume succeeded.
 func mustLink(t *testing.T, db *librarymanager.Database, libraryID, volumeID string) {
 	t.Helper()

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -110,11 +110,10 @@ func TestDatabasePackageTracking(t *testing.T) {
 	mustLink(t, db, "lib-java", "vol-2")
 	mustLink(t, db, "lib-php", "vol-3")
 
-	volumeLinks, _, _ := db.Snapshot()
 	require.Equal(t, map[string]int{
 		"dd-lib-java-init": 2,
 		"dd-lib-php-init":  1,
-	}, volumeLinks)
+	}, db.Snapshot().VolumeLinksByPackage)
 
 	pkg, err := db.GetPackageForLibrary("lib-java")
 	require.NoError(t, err)
@@ -133,11 +132,10 @@ func TestDatabasePackageTracking(t *testing.T) {
 	// entry is kept in the snapshot at zero rather than removed: dashboards
 	// can then observe the "no volumes" transition explicitly.
 	require.NoError(t, db.UnlinkVolume("lib-php", "vol-3"))
-	volumeLinks, _, _ = db.Snapshot()
 	require.Equal(t, map[string]int{
 		"dd-lib-java-init": 2,
 		"dd-lib-php-init":  0,
-	}, volumeLinks)
+	}, db.Snapshot().VolumeLinksByPackage)
 }
 
 func TestDatabaseLinkWithoutRegistrationFallsBackToEmptyPackage(t *testing.T) {
@@ -152,8 +150,7 @@ func TestDatabaseLinkWithoutRegistrationFallsBackToEmptyPackage(t *testing.T) {
 	// AddLibrary has run, so no Package is registered.
 	mustLink(t, db, "lib-legacy", "vol-legacy")
 
-	volumeLinks, _, _ := db.Snapshot()
-	require.Equal(t, map[string]int{"": 1}, volumeLinks, "unregistered libraries surface under the empty key")
+	require.Equal(t, map[string]int{"": 1}, db.Snapshot().VolumeLinksByPackage, "unregistered libraries surface under the empty key")
 
 	pkg, err := db.GetPackageForLibrary("lib-legacy")
 	require.NoError(t, err)
@@ -172,9 +169,9 @@ func TestDatabaseLibraryMetadataCacheLifecycle(t *testing.T) {
 	// upgrade-from-pre-feature scenario: no Package or cache state is
 	// registered.
 	mustLink(t, db, "lib-java", "vol-1")
-	_, counts, bytes := db.Snapshot()
-	require.Empty(t, counts)
-	require.Empty(t, bytes)
+	snap := db.Snapshot()
+	require.Empty(t, snap.CachedCountByPackage)
+	require.Empty(t, snap.CachedBytesByPackage)
 
 	// First AddLibrary registers the package and publishes the
 	// library at its measured size.
@@ -183,9 +180,9 @@ func TestDatabaseLibraryMetadataCacheLifecycle(t *testing.T) {
 	require.Equal(t, 1, count)
 	require.Equal(t, int64(12_345), byteTotal)
 
-	_, counts, bytes = db.Snapshot()
-	require.Equal(t, map[string]int{"dd-lib-java-init": 1}, counts)
-	require.Equal(t, map[string]int64{"dd-lib-java-init": 12_345}, bytes)
+	snap = db.Snapshot()
+	require.Equal(t, map[string]int{"dd-lib-java-init": 1}, snap.CachedCountByPackage)
+	require.Equal(t, map[string]int64{"dd-lib-java-init": 12_345}, snap.CachedBytesByPackage)
 
 	// Re-caching the same library replaces the size, not the count. This is
 	// a defensive path for any future in-place re-cache; the package totals
@@ -195,8 +192,7 @@ func TestDatabaseLibraryMetadataCacheLifecycle(t *testing.T) {
 	require.Equal(t, 1, count, "re-caching must not bump the package count")
 	require.Equal(t, int64(99_999), byteTotal)
 
-	_, _, bytes = db.Snapshot()
-	require.Equal(t, map[string]int64{"dd-lib-java-init": 99_999}, bytes)
+	require.Equal(t, map[string]int64{"dd-lib-java-init": 99_999}, db.Snapshot().CachedBytesByPackage)
 
 	// RemoveLibrary drops the cache state and wipes the metadata entry.
 	require.NoError(t, db.RemoveLibrary("lib-java"))
@@ -221,9 +217,9 @@ func TestDatabaseRemoveLibraryUnknownIsNoop(t *testing.T) {
 	// snapshot and must not materialize a metadata entry for it.
 	require.NoError(t, db.RemoveLibrary("lib-unknown"))
 
-	_, counts, bytes := db.Snapshot()
-	require.Empty(t, counts)
-	require.Empty(t, bytes)
+	snap := db.Snapshot()
+	require.Empty(t, snap.CachedCountByPackage)
+	require.Empty(t, snap.CachedBytesByPackage)
 
 	pkg, err := db.GetPackageForLibrary("lib-unknown")
 	require.NoError(t, err)
@@ -255,24 +251,21 @@ func TestDatabaseAggregatesAcrossMultipleVersionsOfTheSamePackage(t *testing.T) 
 	require.NoError(t, db.AddLibrary(php82, phpPackage, 5_500_000))
 	mustLink(t, db, php82, "vol-c")
 
-	volumeLinks, _, _ := db.Snapshot()
-	require.Equal(t, map[string]int{phpPackage: 3}, volumeLinks,
+	snap := db.Snapshot()
+	require.Equal(t, map[string]int{phpPackage: 3}, snap.VolumeLinksByPackage,
 		"volume links must be summed across every version of the same package")
+	require.Equal(t, map[string]int{phpPackage: 2}, snap.CachedCountByPackage)
+	require.Equal(t, map[string]int64{phpPackage: 10_500_000}, snap.CachedBytesByPackage)
 
 	count, bytesTotal := db.PackageCacheStats(phpPackage)
 	require.Equal(t, 2, count, "the package must count both cached versions")
 	require.Equal(t, int64(10_500_000), bytesTotal, "package bytes must sum every cached version")
 
-	_, counts, bytes := db.Snapshot()
-	require.Equal(t, map[string]int{phpPackage: 2}, counts)
-	require.Equal(t, map[string]int64{phpPackage: 10_500_000}, bytes)
-
 	// Unlinking the volumes of one version drops the link count for the
 	// package by one each; the package label stays the same.
 	require.NoError(t, db.UnlinkVolume(php81, "vol-a"))
 	require.NoError(t, db.UnlinkVolume(php81, "vol-b"))
-	volumeLinks, _, _ = db.Snapshot()
-	require.Equal(t, map[string]int{phpPackage: 1}, volumeLinks)
+	require.Equal(t, map[string]int{phpPackage: 1}, db.Snapshot().VolumeLinksByPackage)
 
 	// Evicting one version drops the package count by one and removes only
 	// the corresponding bytes; the other version is untouched. In practice

--- a/pkg/librarymanager/downloader.go
+++ b/pkg/librarymanager/downloader.go
@@ -41,8 +41,8 @@ func NewDownloaderWithRoundTripper(roundTripper http.RoundTripper) *Downloader {
 }
 
 // Download will stream a container image and extract the source directory from inside of the image to the destination
-// directory on disk.
-func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string, dst string) error {
+// directory on disk. Returns the cumulative size of the regular files written.
+func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string, dst string) (int64, error) {
 	img, err := crane.Pull(image,
 		crane.WithContext(ctx),
 		crane.WithUserAgent(userAgent),
@@ -50,7 +50,7 @@ func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string
 		crane.WithPlatform(&v1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}),
 	)
 	if err != nil {
-		return fmt.Errorf("could not pull %s: %w", image, err)
+		return 0, fmt.Errorf("could not pull %s: %w", image, err)
 	}
 
 	pr, pw := io.Pipe()
@@ -61,14 +61,14 @@ func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string
 	// Extract the entire image content
 	fp, err := NewArchiveExtractor(afs, "/", dst)
 	if err != nil {
-		return fmt.Errorf("could not setup archive extractor: %w", err)
+		return 0, fmt.Errorf("could not setup archive extractor: %w", err)
 	}
-	err = fp.Extract(ctx, pr)
+	bytes, err := fp.Extract(ctx, pr)
 	if err != nil {
-		return fmt.Errorf("could not extract archive: %w", err)
+		return 0, fmt.Errorf("could not extract archive: %w", err)
 	}
 
-	return nil
+	return bytes, nil
 }
 
 // FetchDigest will fetch a sha256 sum of the image and return it.

--- a/pkg/librarymanager/downloader_test.go
+++ b/pkg/librarymanager/downloader_test.go
@@ -54,7 +54,7 @@ func TestDownload(t *testing.T) {
 			require.Equal(t, test.expectedDigest, digest)
 
 			// Ensure downloaded files match the expected.
-			err = d.Download(ctx, afero.Afero{Fs: afero.NewOsFs()}, image, tsd.Path(t))
+			size, err := d.Download(ctx, afero.Afero{Fs: afero.NewOsFs()}, image, tsd.Path(t))
 			require.NoError(t, err, "error found when downloading")
 
 			// Ensure expected files exist.
@@ -63,6 +63,21 @@ func TestDownload(t *testing.T) {
 				_, err := os.Stat(checkPath)
 				require.NoError(t, err, "expected file %s to exist", checkPath)
 			}
+
+			// Ensure the reported size matches the cumulative size of the
+			// regular files actually written under the destination.
+			var expectedSize int64
+			err = filepath.Walk(tsd.Path(t), func(_ string, info os.FileInfo, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				if info.Mode().IsRegular() {
+					expectedSize += info.Size()
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, expectedSize, size, "Download must report the cumulative regular-file size")
 		})
 	}
 }

--- a/pkg/librarymanager/library.go
+++ b/pkg/librarymanager/library.go
@@ -43,6 +43,16 @@ func (l *Library) Pull() bool {
 	return l.pull
 }
 
+// Name returns the package name of the library (e.g. dd-lib-java-init, apm-inject).
+func (l *Library) Name() string {
+	return l.name
+}
+
+// Registry returns the registry the library is pulled from.
+func (l *Library) Registry() string {
+	return l.registry
+}
+
 // Image provides a container image path pullable by crane.
 // Handles tag, digest, and tag@digest versions:
 //   - Tags: registry/name:v1.0.0

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Datadog/datadog-csi-driver/pkg/metrics"
 	"github.com/spf13/afero"
 )
 
@@ -47,6 +46,13 @@ type LibraryManager struct {
 	cleanupStrategy CleanupStrategy
 	// scratchDir is the directory used for scratch download space for libraries.
 	scratchDir string
+	// listener is notified of every significant lifecycle event. It defaults
+	// to a no-op so the manager can always invoke it unconditionally; the
+	// production wiring (cmd/driver) passes a metrics-publishing listener
+	// from pkg/metrics. The listener is responsible for any observability
+	// concern (metrics, audit, etc.); the manager itself stays free of any
+	// dependency on a concrete backend.
+	listener EventListener
 }
 
 // LibraryManagerOption is a functional option for configuring a LibraryManager.
@@ -74,6 +80,18 @@ func WithCleanupStrategy(s CleanupStrategy) LibraryManagerOption {
 	}
 }
 
+// WithEventListener injects an EventListener. Without this option the
+// manager uses a no-op listener; the production wiring should always pass
+// an implementation that publishes metrics (or any other observability
+// signal).
+func WithEventListener(l EventListener) LibraryManagerOption {
+	return func(lm *LibraryManager) {
+		if l != nil {
+			lm.listener = l
+		}
+	}
+}
+
 // NewLibraryManager creates a new library manager with all of the required dependencies.
 // The basePath is required as an absolute path (rather than using afero.NewBasePathFs) because
 // bind mounts need absolute paths.
@@ -84,6 +102,7 @@ func NewLibraryManager(basePath string, opts ...LibraryManagerOption) (*LibraryM
 		downloader:      NewDownloader(),
 		locker:          NewLocker(),
 		cleanupStrategy: NewImmediateCleanupStrategy(),
+		listener:        noopEventListener{},
 	}
 
 	// Apply options.
@@ -123,6 +142,11 @@ func NewLibraryManager(basePath string, opts ...LibraryManagerOption) (*LibraryM
 	// Setup cache.
 	lm.cache = NewImageCache(lm.downloader, DefaultImageCacheTTL)
 
+	// Notify the listener of the persisted state so stateful gauges reflect
+	// reality immediately after a restart, without waiting for the first
+	// lifecycle event to flow through.
+	lm.listener.OnSnapshot(lm.db.Snapshot())
+
 	return lm, nil
 }
 
@@ -144,11 +168,11 @@ func (lm *LibraryManager) HasVolume(volumeID string) (bool, error) {
 // GetLibraryForVolume fetches the remote library if it doesn't exist, records its usage, and returns the path on disk
 // that can be mounted for the volume.
 func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID string, lib *Library) (string, error) {
-	// Track the resolution outcome for metrics. Default to "failed" so that any
-	// early return is reported as a failure unless explicitly overridden.
-	result := metrics.ResolutionFailed
+	// Track the resolution outcome for the listener. Default to "failed" so
+	// any early return is reported as a failure unless explicitly overridden.
+	result := LibraryResolutionFailed
 	defer func() {
-		metrics.RecordLibraryResolution(result)
+		lm.listener.OnLibraryResolved(result)
 	}()
 
 	// Validate the input.
@@ -165,24 +189,24 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return "", fmt.Errorf("could not determine library ID: %w", err)
 	}
 
-	// Lock the package.
+	// Lock the package. Held across the entire resolution so that any cleanup
+	// scheduled for this libraryID by a concurrent RemoveVolume is serialized
+	// with the work below; this is what protects an in-flight download from
+	// being evicted out from under us.
 	lm.locker.Lock(libraryID)
 	defer lm.locker.Unlock(libraryID)
 
-	// Link the library as a first step to ensure any cleanup processes know we need this library.
-	err = lm.db.LinkVolume(libraryID, volumeID)
-	if err != nil {
-		return "", err
-	}
-
-	// If the library already exists, return it.
+	// If the library already exists on disk, link the volume and return it.
 	path, err := lm.store.Get(libraryID)
 	if err != nil && !errors.Is(err, ErrItemNotFound) {
 		return "", err
 	}
 	if path != "" {
 		log.Info("Library already cached", "image", lib.Image(), "path", path)
-		result = metrics.ResolutionCacheHit
+		if err := lm.linkVolume(libraryID, volumeID); err != nil {
+			return "", err
+		}
+		result = LibraryResolutionCacheHit
 		return path, nil
 	}
 
@@ -196,11 +220,11 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	// Download the library into the scratch space.
 	log.Info("Downloading library", "image", lib.Image())
 	downloadStart := time.Now()
-	err = lm.downloader.Download(ctx, lm.fs, lib.Image(), scratch)
+	size, err := lm.downloader.Download(ctx, lm.fs, lib.Image(), scratch)
 	if err != nil {
 		return "", err
 	}
-	metrics.ObserveLibraryDownloadDuration(lib.Name(), lib.Registry(), time.Since(downloadStart))
+	lm.listener.OnLibraryDownload(lib.Name(), lib.Registry(), time.Since(downloadStart))
 
 	// Copy the library into the store.
 	storePath, err := lm.store.Add(libraryID, scratch)
@@ -208,27 +232,76 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return "", err
 	}
 	log.Info("Library downloaded and stored", "image", lib.Image(), "path", storePath)
-	result = metrics.ResolutionDownloaded
+
+	// Register the library metadata (package name, size, cached flag) before
+	// linking any volume so the per-package aggregates are correct from the
+	// very first link.
+	lm.recordLibraryCached(libraryID, lib.Name(), size)
+
+	// Link the volume to the library only after the payload is actually on
+	// disk so a failed download never leaves a dangling link behind.
+	if err := lm.linkVolume(libraryID, volumeID); err != nil {
+		return "", err
+	}
+	result = LibraryResolutionDownloaded
 	return storePath, nil
+}
+
+// linkVolume persists the volume→library link and publishes the per-package
+// volume_links gauge via the listener. The package label is read from the
+// database, which is populated by recordLibraryCached at download time.
+func (lm *LibraryManager) linkVolume(libraryID, volumeID string) error {
+	if err := lm.db.LinkVolume(libraryID, volumeID); err != nil {
+		return err
+	}
+	pkg, _ := lm.db.GetPackageForLibrary(libraryID)
+	lm.listener.OnVolumeLinked(pkg, lm.db.VolumeLinkCount(pkg))
+	return nil
+}
+
+// recordLibraryCached persists the metadata of a newly downloaded library
+// (package name, size, cached flag) and publishes the libraries_cached*
+// gauges via the listener. Errors are logged but never propagated: a stale
+// gauge does not justify failing the mount flow.
+func (lm *LibraryManager) recordLibraryCached(libraryID, pkg string, size int64) {
+	if err := lm.db.AddLibrary(libraryID, pkg, size); err != nil {
+		log.Warn("Could not persist library cache metadata, libraries_cached* gauges may be stale across restarts", "library_id", libraryID, "error", err)
+		return
+	}
+	count, bytes := lm.db.PackageCacheStats(pkg)
+	lm.listener.OnLibraryCached(pkg, count, bytes)
 }
 
 // RemoveVolume removes the link between the LibraryID and the VolumeID in the database.
 // If there are no more uses of the library, it is also removed from disk.
 func (lm *LibraryManager) RemoveVolume(ctx context.Context, volumeID string) error {
-	// Look up the linked library.
+	// Look up the linked library and its package up front: once UnlinkVolume
+	// drops the last reference, future cleanup runs may wipe the metadata
+	// entry, so we cache the package here while it is still resolvable.
 	libraryID, err := lm.db.GetLibraryForVolume(volumeID)
 	if err != nil {
 		return fmt.Errorf("could not determine which library was linked for volume %s: %w", volumeID, err)
+	}
+	if libraryID == "" {
+		// No link was ever recorded for this volume (typically because
+		// NodePublishVolume failed before the volume could be linked, then
+		// kubelet still calls NodeUnpublishVolume on pod deletion). Nothing
+		// to unlink, nothing to clean up.
+		return nil
+	}
+	pkg, err := lm.db.GetPackageForLibrary(libraryID)
+	if err != nil {
+		return fmt.Errorf("could not determine package for library %s: %w", libraryID, err)
 	}
 
 	// Unlink the volume from the database.
 	// Note: No lock needed here because:
 	// - UnlinkVolume is atomic (database has its own locking)
 	// - tryCleanupLibrary acquires the lock before checking and removing
-	err = lm.db.UnlinkVolume(libraryID, volumeID)
-	if err != nil {
+	if err := lm.db.UnlinkVolume(libraryID, volumeID); err != nil {
 		return fmt.Errorf("could not unlink volume ID %s: %w", volumeID, err)
 	}
+	lm.listener.OnVolumeUnlinked(pkg, lm.db.VolumeLinkCount(pkg))
 
 	// Schedule cleanup - tryCleanupLibrary will check if the library is still in use
 	lm.cleanupStrategy.ScheduleCleanup(libraryID, lm.tryCleanupLibrary)
@@ -248,19 +321,29 @@ func (lm *LibraryManager) tryCleanupLibrary(libraryID string) error {
 	// Check if the library is still in use
 	count, err := lm.db.GetVolumeCount(libraryID)
 	if err != nil {
-		metrics.RecordLibraryCleanup(metrics.CleanupFailed, strategy)
+		lm.listener.OnLibraryCleanup(LibraryCleanupFailed, strategy)
 		return fmt.Errorf("could not get linked library count: %w", err)
 	}
 	if count > 0 {
 		log.Info("Library still in use, skipping cleanup", "library_id", libraryID, "count", count)
-		metrics.RecordLibraryCleanup(metrics.CleanupSkippedInUse, strategy)
+		lm.listener.OnLibraryCleanup(LibraryCleanupSkippedInUse, strategy)
 		return nil
 	}
 	log.Info("Removing library from disk", "library_id", libraryID)
 	if err := lm.store.Remove(libraryID); err != nil {
-		metrics.RecordLibraryCleanup(metrics.CleanupFailed, strategy)
+		lm.listener.OnLibraryCleanup(LibraryCleanupFailed, strategy)
 		return err
 	}
-	metrics.RecordLibraryCleanup(metrics.CleanupSuccess, strategy)
+	// Drop the cache state. The package is captured up front so we can
+	// still publish the per-package aggregate after the metadata entry is
+	// gone.
+	pkg, _ := lm.db.GetPackageForLibrary(libraryID)
+	if err := lm.db.RemoveLibrary(libraryID); err != nil {
+		log.Warn("Could not remove library metadata, libraries_cached* gauges may be stale", "library_id", libraryID, "error", err)
+	} else {
+		count, bytes := lm.db.PackageCacheStats(pkg)
+		lm.listener.OnLibraryEvicted(pkg, count, bytes)
+	}
+	lm.listener.OnLibraryCleanup(LibraryCleanupSuccess, strategy)
 	return nil
 }

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Datadog/datadog-csi-driver/pkg/metrics"
 	"github.com/spf13/afero"
 )
 
@@ -143,6 +144,13 @@ func (lm *LibraryManager) HasVolume(volumeID string) (bool, error) {
 // GetLibraryForVolume fetches the remote library if it doesn't exist, records its usage, and returns the path on disk
 // that can be mounted for the volume.
 func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID string, lib *Library) (string, error) {
+	// Track the resolution outcome for metrics. Default to "failed" so that any
+	// early return is reported as a failure unless explicitly overridden.
+	result := metrics.ResolutionFailed
+	defer func() {
+		metrics.RecordLibraryResolution(result)
+	}()
+
 	// Validate the input.
 	if volumeID == "" {
 		return "", fmt.Errorf("volume ID cannot be empty")
@@ -174,6 +182,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	}
 	if path != "" {
 		log.Info("Library already cached", "image", lib.Image(), "path", path)
+		result = metrics.ResolutionCacheHit
 		return path, nil
 	}
 
@@ -186,10 +195,12 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 
 	// Download the library into the scratch space.
 	log.Info("Downloading library", "image", lib.Image())
+	downloadStart := time.Now()
 	err = lm.downloader.Download(ctx, lm.fs, lib.Image(), scratch)
 	if err != nil {
 		return "", err
 	}
+	metrics.ObserveLibraryDownloadDuration(lib.Name(), lib.Registry(), time.Since(downloadStart))
 
 	// Copy the library into the store.
 	storePath, err := lm.store.Add(libraryID, scratch)
@@ -197,6 +208,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return "", err
 	}
 	log.Info("Library downloaded and stored", "image", lib.Image(), "path", storePath)
+	result = metrics.ResolutionDownloaded
 	return storePath, nil
 }
 
@@ -227,6 +239,8 @@ func (lm *LibraryManager) RemoveVolume(ctx context.Context, volumeID string) err
 // tryCleanupLibrary attempts to remove a library from disk if it's no longer in use.
 // It acquires the lock and checks the volume count before removing.
 func (lm *LibraryManager) tryCleanupLibrary(libraryID string) error {
+	strategy := lm.cleanupStrategy.Name()
+
 	// Acquire lock to prevent race with GetLibraryForVolume
 	lm.locker.Lock(libraryID)
 	defer lm.locker.Unlock(libraryID)
@@ -234,12 +248,19 @@ func (lm *LibraryManager) tryCleanupLibrary(libraryID string) error {
 	// Check if the library is still in use
 	count, err := lm.db.GetVolumeCount(libraryID)
 	if err != nil {
+		metrics.RecordLibraryCleanup(metrics.CleanupFailed, strategy)
 		return fmt.Errorf("could not get linked library count: %w", err)
 	}
 	if count > 0 {
 		log.Info("Library still in use, skipping cleanup", "library_id", libraryID, "count", count)
+		metrics.RecordLibraryCleanup(metrics.CleanupSkippedInUse, strategy)
 		return nil
 	}
 	log.Info("Removing library from disk", "library_id", libraryID)
-	return lm.store.Remove(libraryID)
+	if err := lm.store.Remove(libraryID); err != nil {
+		metrics.RecordLibraryCleanup(metrics.CleanupFailed, strategy)
+		return err
+	}
+	metrics.RecordLibraryCleanup(metrics.CleanupSuccess, strategy)
+	return nil
 }

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -215,7 +215,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	if err != nil {
 		return "", fmt.Errorf("could not create scratch directory: %w", err)
 	}
-	defer lm.fs.RemoveAll(scratch)
+	defer func() { _ = lm.fs.RemoveAll(scratch) }()
 
 	// Download the library into the scratch space.
 	log.Info("Downloading library", "image", lib.Image())

--- a/pkg/librarymanager/librarymanager_test.go
+++ b/pkg/librarymanager/librarymanager_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +20,22 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
+
+// failingStoreRemovalFs wraps an afero.Fs and forces RemoveAll to fail for
+// any path under storePrefix. Used to exercise the cleanup-failed branch of
+// tryCleanupLibrary without relying on POSIX permission bits (which root
+// silently bypasses on CI).
+type failingStoreRemovalFs struct {
+	afero.Fs
+	storePrefix string
+}
+
+func (f *failingStoreRemovalFs) RemoveAll(path string) error {
+	if strings.HasPrefix(path, f.storePrefix) {
+		return fmt.Errorf("simulated store removal failure")
+	}
+	return f.Fs.RemoveAll(path)
+}
 
 type testImage struct {
 	tarPath string
@@ -390,10 +407,10 @@ func TestLibraryManagerWithCleanupStrategyAndEventListener(t *testing.T) {
 }
 
 // TestLibraryManagerCleanupFailedWhenStoreRemoveFails surfaces the
-// LibraryCleanupFailed branch of tryCleanupLibrary. We get there by making
-// the store filesystem read-only after the library has been added: the
-// subsequent RemoveAll fails, the manager surfaces a Failed cleanup event,
-// and the library remains on disk.
+// LibraryCleanupFailed branch of tryCleanupLibrary by wrapping the
+// filesystem so RemoveAll fails for paths under the store directory. We
+// avoid POSIX chmod because root (the user the tests run as on CI)
+// silently ignores permission bits and the cleanup would succeed anyway.
 func TestLibraryManagerCleanupFailedWhenStoreRemoveFails(t *testing.T) {
 	localRegistry := testutil.NewLocalRegistry(t)
 	defer localRegistry.Stop()
@@ -402,9 +419,12 @@ func TestLibraryManagerCleanupFailedWhenStoreRemoveFails(t *testing.T) {
 	tsd := testutil.NewTempScratchDirectory(t)
 	defer tsd.Cleanup(t)
 
+	storeDir := filepath.Join(tsd.Path(t), librarymanager.StoreDirectory)
+	fs := afero.Afero{Fs: &failingStoreRemovalFs{Fs: afero.NewOsFs(), storePrefix: storeDir}}
+
 	listener := &fakeListener{}
 	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
-		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithFilesystem(fs),
 		librarymanager.WithDownloader(librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))),
 		librarymanager.WithEventListener(listener),
 	)
@@ -417,13 +437,6 @@ func TestLibraryManagerCleanupFailedWhenStoreRemoveFails(t *testing.T) {
 	ctx := context.Background()
 	_, err = lm.GetLibraryForVolume(ctx, "vol-1", lib)
 	require.NoError(t, err)
-
-	// Make the store directory read-only so RemoveAll fails inside
-	// tryCleanupLibrary. The defer restores permissions before
-	// tsd.Cleanup runs (LIFO order) so the scratch tear-down succeeds.
-	storeDir := filepath.Join(tsd.Path(t), librarymanager.StoreDirectory)
-	require.NoError(t, os.Chmod(storeDir, 0o555))
-	defer func() { _ = os.Chmod(storeDir, 0o755) }()
 
 	require.NoError(t, lm.RemoveVolume(ctx, "vol-1"),
 		"RemoveVolume itself succeeds; only the async cleanup fails")

--- a/pkg/librarymanager/librarymanager_test.go
+++ b/pkg/librarymanager/librarymanager_test.go
@@ -7,6 +7,7 @@ package librarymanager_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -165,4 +166,43 @@ func createTestLibrary(t *testing.T, tl *testVolume, registry string) *libraryma
 	lib, err := librarymanager.NewLibrary(tl.name, registry, tl.version, tl.pull)
 	require.NoError(t, err)
 	return lib
+}
+
+// TestLibraryManagerStartupResync ensures the manager can be created on top of a
+// database that already contains links (as happens after a driver restart) and
+// that the persisted package names are preserved.
+func TestLibraryManagerStartupResync(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+	basePath := tsd.Path(t)
+
+	// Pre-populate the database with two libraries and three linked volumes,
+	// covering two packages.
+	dbDir := filepath.Join(basePath, librarymanager.DatabaseDirectory)
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	db, err := librarymanager.NewDatabase(dbDir)
+	require.NoError(t, err)
+	require.NoError(t, db.AddLibrary("lib-java", "dd-lib-java-init", 0))
+	require.NoError(t, db.AddLibrary("lib-php", "dd-lib-php-init", 0))
+	require.NoError(t, db.LinkVolume("lib-java", "vol-1"))
+	require.NoError(t, db.LinkVolume("lib-java", "vol-2"))
+	require.NoError(t, db.LinkVolume("lib-php", "vol-3"))
+	require.NoError(t, db.Close())
+
+	// Bringing up a manager on the same base path must succeed; this also
+	// resynchronizes the library_volume_links gauge in the background.
+	lm, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, lm.Stop())
+	}()
+
+	// The persisted volume links remain visible after restart.
+	for _, volumeID := range []string{"vol-1", "vol-2", "vol-3"} {
+		has, err := lm.HasVolume(volumeID)
+		require.NoError(t, err)
+		require.Truef(t, has, "expected %s to still be tracked after manager restart", volumeID)
+	}
 }

--- a/pkg/librarymanager/librarymanager_test.go
+++ b/pkg/librarymanager/librarymanager_test.go
@@ -7,9 +7,12 @@ package librarymanager_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
 	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
@@ -205,4 +208,226 @@ func TestLibraryManagerStartupResync(t *testing.T) {
 		require.NoError(t, err)
 		require.Truef(t, has, "expected %s to still be tracked after manager restart", volumeID)
 	}
+}
+
+// fakeListener is a thread-safe librarymanager.EventListener that records
+// every event in the order it is observed. Used by the integration test
+// below to assert the manager publishes the expected sequence end-to-end.
+type fakeListener struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (f *fakeListener) record(s string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, s)
+}
+
+func (f *fakeListener) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.events))
+	copy(out, f.events)
+	return out
+}
+
+func (f *fakeListener) OnLibraryResolved(r librarymanager.LibraryResolutionResult) {
+	f.record(fmt.Sprintf("resolved=%s", r))
+}
+func (f *fakeListener) OnLibraryDownload(library, _ string, _ time.Duration) {
+	f.record(fmt.Sprintf("download=%s", library))
+}
+func (f *fakeListener) OnLibraryCleanup(s librarymanager.LibraryCleanupStatus, _ string) {
+	f.record(fmt.Sprintf("cleanup=%s", s))
+}
+func (f *fakeListener) OnVolumeLinked(pkg string, n int) {
+	f.record(fmt.Sprintf("linked=%s/%d", pkg, n))
+}
+func (f *fakeListener) OnVolumeUnlinked(pkg string, n int) {
+	f.record(fmt.Sprintf("unlinked=%s/%d", pkg, n))
+}
+func (f *fakeListener) OnLibraryCached(pkg string, count int, _ int64) {
+	f.record(fmt.Sprintf("cached=%s/%d", pkg, count))
+}
+func (f *fakeListener) OnLibraryEvicted(pkg string, count int, _ int64) {
+	f.record(fmt.Sprintf("evicted=%s/%d", pkg, count))
+}
+func (f *fakeListener) OnSnapshot(s librarymanager.Snapshot) {
+	f.record(fmt.Sprintf("snapshot=%d/%d/%d",
+		len(s.VolumeLinksByPackage), len(s.CachedCountByPackage), len(s.CachedBytesByPackage)))
+}
+
+// TestLibraryManagerEventListenerSequence wires a fake listener into a real
+// manager backed by a local registry and asserts every lifecycle event is
+// published in the expected order across a download, a cache hit, and two
+// cleanup paths (skipped_in_use then success).
+func TestLibraryManagerEventListenerSequence(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	localRegistry.AddImage(t, "testdata/image.tar", "test-image", "latest")
+
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	listener := &fakeListener{}
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))),
+		librarymanager.WithEventListener(listener),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+
+	// OnSnapshot must fire at startup, even on an empty database.
+	require.Equal(t, []string{"snapshot=0/0/0"}, listener.snapshot(),
+		"OnSnapshot must be invoked exactly once at NewLibraryManager")
+
+	lib, err := librarymanager.NewLibrary("test-image", localRegistry.Registry(t), "latest", false)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// First mount: download → cached → linked → resolved.
+	_, err = lm.GetLibraryForVolume(ctx, "vol-1", lib)
+	require.NoError(t, err)
+
+	// Second mount on the same library: cache hit → linked → resolved.
+	_, err = lm.GetLibraryForVolume(ctx, "vol-2", lib)
+	require.NoError(t, err)
+
+	// First unlink: should NOT trigger eviction since vol-2 still uses
+	// the library; cleanup must report skipped_in_use.
+	require.NoError(t, lm.RemoveVolume(ctx, "vol-1"))
+
+	// Second unlink: the library is now orphan, eviction fires.
+	require.NoError(t, lm.RemoveVolume(ctx, "vol-2"))
+
+	got := listener.snapshot()
+	require.Equal(t, []string{
+		"snapshot=0/0/0",
+		"download=test-image",
+		"cached=test-image/1",
+		"linked=test-image/1",
+		"resolved=downloaded",
+		"linked=test-image/2",
+		"resolved=cache_hit",
+		"unlinked=test-image/1",
+		"cleanup=skipped_in_use",
+		"unlinked=test-image/0",
+		"evicted=test-image/0",
+		"cleanup=success",
+	}, got, "the listener must observe the full lifecycle in the expected order")
+}
+
+// TestLibraryManagerGetLibraryForVolumeValidatesInputs covers the two
+// "user error" branches that the production wiring should never hit but the
+// API still has to guard.
+func TestLibraryManagerGetLibraryForVolumeValidatesInputs(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+
+	_, err = lm.GetLibraryForVolume(context.Background(), "", &librarymanager.Library{})
+	require.Error(t, err, "empty volumeID must be rejected")
+
+	_, err = lm.GetLibraryForVolume(context.Background(), "vol", nil)
+	require.Error(t, err, "nil library must be rejected")
+}
+
+// TestLibraryManagerRemoveVolumeIsNoopForUnknownVolume covers the
+// NodeUnpublish-after-failed-NodePublish path: kubelet calls RemoveVolume
+// on a volume that was never successfully linked, and we must not error.
+func TestLibraryManagerRemoveVolumeIsNoopForUnknownVolume(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	listener := &fakeListener{}
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithEventListener(listener),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+
+	require.NoError(t, lm.RemoveVolume(context.Background(), "vol-never-linked"),
+		"RemoveVolume on an unknown volume must be a no-op, not an error")
+
+	// Beyond the startup snapshot, nothing should have been emitted.
+	require.Equal(t, []string{"snapshot=0/0/0"}, listener.snapshot(),
+		"a no-op RemoveVolume must not publish any lifecycle event")
+}
+
+// TestLibraryManagerWithCleanupStrategyAndEventListener exercises both
+// options in isolation by constructing a manager with non-default values
+// and asserting the options were applied.
+func TestLibraryManagerWithCleanupStrategyAndEventListener(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	listener := &fakeListener{}
+	strategy := librarymanager.NewDelayedCleanupStrategy(50 * time.Millisecond)
+
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithCleanupStrategy(strategy),
+		librarymanager.WithEventListener(listener),
+	)
+	require.NoError(t, err)
+
+	// Listener wiring is confirmed by the OnSnapshot recorded at startup.
+	require.Equal(t, []string{"snapshot=0/0/0"}, listener.snapshot())
+
+	// CleanupStrategy wiring is confirmed by Stop draining the strategy
+	// (DelayedCleanupStrategy.Stop is the only way Stop can fail to be a
+	// no-op).
+	require.NoError(t, lm.Stop())
+}
+
+// TestLibraryManagerCleanupFailedWhenStoreRemoveFails surfaces the
+// LibraryCleanupFailed branch of tryCleanupLibrary. We get there by making
+// the store filesystem read-only after the library has been added: the
+// subsequent RemoveAll fails, the manager surfaces a Failed cleanup event,
+// and the library remains on disk.
+func TestLibraryManagerCleanupFailedWhenStoreRemoveFails(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	localRegistry.AddImage(t, "testdata/image.tar", "test-image", "latest")
+
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	listener := &fakeListener{}
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))),
+		librarymanager.WithEventListener(listener),
+	)
+	require.NoError(t, err)
+	defer func() { _ = lm.Stop() }()
+
+	lib, err := librarymanager.NewLibrary("test-image", localRegistry.Registry(t), "latest", false)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = lm.GetLibraryForVolume(ctx, "vol-1", lib)
+	require.NoError(t, err)
+
+	// Make the store directory read-only so RemoveAll fails inside
+	// tryCleanupLibrary. The defer restores permissions before
+	// tsd.Cleanup runs (LIFO order) so the scratch tear-down succeeds.
+	storeDir := filepath.Join(tsd.Path(t), librarymanager.StoreDirectory)
+	require.NoError(t, os.Chmod(storeDir, 0o555))
+	defer func() { _ = os.Chmod(storeDir, 0o755) }()
+
+	require.NoError(t, lm.RemoveVolume(ctx, "vol-1"),
+		"RemoveVolume itself succeeds; only the async cleanup fails")
+
+	require.Contains(t, listener.snapshot(), "cleanup=failed",
+		"the cleanup-failed event must reach the listener so dashboards can alert")
 }

--- a/pkg/librarymanager/listener.go
+++ b/pkg/librarymanager/listener.go
@@ -30,6 +30,21 @@ const (
 	LibraryCleanupSkippedInUse LibraryCleanupStatus = "skipped_in_use"
 )
 
+// Snapshot is the full per-package state captured atomically from the
+// database. Used by EventListener.OnSnapshot to seed stateful gauges at
+// startup. The maps are owned by the caller and must not be retained.
+type Snapshot struct {
+	// VolumeLinksByPackage is the number of volumes currently linked to
+	// each package.
+	VolumeLinksByPackage map[string]int
+	// CachedCountByPackage is the number of library versions currently
+	// cached on disk for each package.
+	CachedCountByPackage map[string]int
+	// CachedBytesByPackage is the total on-disk size in bytes of the
+	// cached library versions for each package.
+	CachedBytesByPackage map[string]int64
+}
+
 // EventListener is notified by the LibraryManager of significant lifecycle
 // events. The interface is deliberately observability-agnostic: the default
 // implementation is a no-op (see noopEventListener) and the production code
@@ -80,11 +95,10 @@ type EventListener interface {
 	// OnSnapshot is called once at LibraryManager startup with the full
 	// per-package aggregates rebuilt from the persisted state. Listeners
 	// publishing stateful gauges should overwrite the gauge values from
-	// this snapshot so monitors and dashboards reflect reality immediately
+	// the snapshot so monitors and dashboards reflect reality immediately
 	// after a restart, without waiting for the first lifecycle event to
-	// flow through. Maps are read-only snapshots owned by the caller and
-	// must not be retained by the listener.
-	OnSnapshot(volumeLinksByPackage, cachedCountByPackage map[string]int, cachedBytesByPackage map[string]int64)
+	// flow through.
+	OnSnapshot(s Snapshot)
 }
 
 // noopEventListener is the default listener used when no observer is
@@ -92,11 +106,11 @@ type EventListener interface {
 // listener unconditionally and keep the call sites clean.
 type noopEventListener struct{}
 
-func (noopEventListener) OnLibraryResolved(LibraryResolutionResult)             {}
-func (noopEventListener) OnLibraryDownload(string, string, time.Duration)       {}
-func (noopEventListener) OnLibraryCleanup(LibraryCleanupStatus, string)         {}
-func (noopEventListener) OnVolumeLinked(string, int)                            {}
-func (noopEventListener) OnVolumeUnlinked(string, int)                          {}
-func (noopEventListener) OnLibraryCached(string, int, int64)                    {}
-func (noopEventListener) OnLibraryEvicted(string, int, int64)                   {}
-func (noopEventListener) OnSnapshot(map[string]int, map[string]int, map[string]int64) {}
+func (noopEventListener) OnLibraryResolved(LibraryResolutionResult)       {}
+func (noopEventListener) OnLibraryDownload(string, string, time.Duration) {}
+func (noopEventListener) OnLibraryCleanup(LibraryCleanupStatus, string)   {}
+func (noopEventListener) OnVolumeLinked(string, int)                      {}
+func (noopEventListener) OnVolumeUnlinked(string, int)                    {}
+func (noopEventListener) OnLibraryCached(string, int, int64)              {}
+func (noopEventListener) OnLibraryEvicted(string, int, int64)             {}
+func (noopEventListener) OnSnapshot(Snapshot)                             {}

--- a/pkg/librarymanager/listener.go
+++ b/pkg/librarymanager/listener.go
@@ -1,0 +1,102 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package librarymanager
+
+import "time"
+
+// LibraryResolutionResult enumerates the outcomes of GetLibraryForVolume.
+// The underlying string values match the labels used by the Datadog CSI
+// driver metrics so listeners that publish Prometheus series can pass them
+// through without remapping.
+type LibraryResolutionResult string
+
+const (
+	LibraryResolutionCacheHit   LibraryResolutionResult = "cache_hit"
+	LibraryResolutionDownloaded LibraryResolutionResult = "downloaded"
+	LibraryResolutionFailed     LibraryResolutionResult = "failed"
+)
+
+// LibraryCleanupStatus enumerates the outcomes of a cleanup attempt for a
+// library that is no longer in use. Underlying string values match the
+// driver metric labels for the same reason as LibraryResolutionResult.
+type LibraryCleanupStatus string
+
+const (
+	LibraryCleanupSuccess      LibraryCleanupStatus = "success"
+	LibraryCleanupFailed       LibraryCleanupStatus = "failed"
+	LibraryCleanupSkippedInUse LibraryCleanupStatus = "skipped_in_use"
+)
+
+// EventListener is notified by the LibraryManager of significant lifecycle
+// events. The interface is deliberately observability-agnostic: the default
+// implementation is a no-op (see noopEventListener) and the production code
+// wires the metrics-aware listener from pkg/metrics. Other consumers (audit
+// logs, custom telemetry, tests) can implement it without dragging in any
+// concrete observability backend.
+//
+// All methods are expected to be quick and non-blocking: they run on the
+// LibraryManager's caller goroutine, sometimes under a per-library lock.
+// Implementations that need to do non-trivial work should fan out internally.
+//
+// The "Package*Count" / "Package*Bytes" arguments are the post-mutation
+// per-package aggregates, already computed by the manager's database layer.
+// Listeners that publish them can do so directly without re-aggregating.
+type EventListener interface {
+	// OnLibraryResolved is called once GetLibraryForVolume finishes. result
+	// reflects whether the library was served from the cache, freshly
+	// downloaded, or the resolution failed.
+	OnLibraryResolved(result LibraryResolutionResult)
+
+	// OnLibraryDownload is called when a library has been fetched from a
+	// registry, with the time spent on the download. Not called on cache
+	// hits or failures before the download step.
+	OnLibraryDownload(library, registry string, duration time.Duration)
+
+	// OnLibraryCleanup is called for every cleanup attempt, including ones
+	// that were skipped because the library is still in use.
+	OnLibraryCleanup(status LibraryCleanupStatus, strategy string)
+
+	// OnVolumeLinked is called after every successful LinkVolume call
+	// (including idempotent re-links). packageVolumeLinkCount is the
+	// current total for the package, computed by the database.
+	OnVolumeLinked(pkg string, packageVolumeLinkCount int)
+
+	// OnVolumeUnlinked is called after every successful UnlinkVolume call
+	// (including no-op unlinks of a non-existent link). The semantics of
+	// packageVolumeLinkCount match OnVolumeLinked.
+	OnVolumeUnlinked(pkg string, packageVolumeLinkCount int)
+
+	// OnLibraryCached is called when a library payload has been added to
+	// the on-disk store.
+	OnLibraryCached(pkg string, packageCachedCount int, packageCachedBytes int64)
+
+	// OnLibraryEvicted is called when a library payload has been removed
+	// from the on-disk store.
+	OnLibraryEvicted(pkg string, packageCachedCount int, packageCachedBytes int64)
+
+	// OnSnapshot is called once at LibraryManager startup with the full
+	// per-package aggregates rebuilt from the persisted state. Listeners
+	// publishing stateful gauges should overwrite the gauge values from
+	// this snapshot so monitors and dashboards reflect reality immediately
+	// after a restart, without waiting for the first lifecycle event to
+	// flow through. Maps are read-only snapshots owned by the caller and
+	// must not be retained by the listener.
+	OnSnapshot(volumeLinksByPackage, cachedCountByPackage map[string]int, cachedBytesByPackage map[string]int64)
+}
+
+// noopEventListener is the default listener used when no observer is
+// configured. It discards every event so the LibraryManager can invoke the
+// listener unconditionally and keep the call sites clean.
+type noopEventListener struct{}
+
+func (noopEventListener) OnLibraryResolved(LibraryResolutionResult)             {}
+func (noopEventListener) OnLibraryDownload(string, string, time.Duration)       {}
+func (noopEventListener) OnLibraryCleanup(LibraryCleanupStatus, string)         {}
+func (noopEventListener) OnVolumeLinked(string, int)                            {}
+func (noopEventListener) OnVolumeUnlinked(string, int)                          {}
+func (noopEventListener) OnLibraryCached(string, int, int64)                    {}
+func (noopEventListener) OnLibraryEvicted(string, int, int64)                   {}
+func (noopEventListener) OnSnapshot(map[string]int, map[string]int, map[string]int64) {}

--- a/pkg/librarymanager/store_test.go
+++ b/pkg/librarymanager/store_test.go
@@ -147,3 +147,4 @@ func TestStore(t *testing.T) {
 	require.False(t, exists, "package should no longer exist exist")
 	require.NoError(t, err, "no error should be returned")
 }
+

--- a/pkg/librarymanager/store_test.go
+++ b/pkg/librarymanager/store_test.go
@@ -148,3 +148,37 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err, "no error should be returned")
 }
 
+// TestStoreValidatesBlankID asserts every public method rejects an empty
+// ID, which is the only invariant a caller can break by accident.
+func TestStoreValidatesBlankID(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	store, err := librarymanager.NewStore(testFs(), filepath.Join(tsd.Path(t), "base-path"))
+	require.NoError(t, err)
+
+	_, err = store.Add("", "/tmp/whatever")
+	require.Error(t, err, "blank id must be rejected by Add")
+	_, err = store.Get("")
+	require.Error(t, err, "blank id must be rejected by Get")
+	require.Error(t, store.Remove(""), "blank id must be rejected by Remove")
+	_, err = store.Exists("")
+	require.Error(t, err, "blank id must be rejected by Exists")
+}
+
+// TestNewStoreRejectsNonDirectoryPath documents that pointing the store at
+// an existing file (a misconfiguration) surfaces as a NewStore error rather
+// than corrupting the file with a later Add.
+func TestNewStoreRejectsNonDirectoryPath(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	// Create a regular file where the store base path is supposed to live.
+	filePath := filepath.Join(tsd.Path(t), "not-a-dir")
+	require.NoError(t, os.WriteFile(filePath, []byte("placeholder"), 0o600))
+
+	store, err := librarymanager.NewStore(testFs(), filePath)
+	require.Error(t, err, "NewStore must refuse a base path that is a regular file")
+	require.Nil(t, store, "store must be nil on error")
+}
+

--- a/pkg/librarymanager/testdata/README.md
+++ b/pkg/librarymanager/testdata/README.md
@@ -30,7 +30,7 @@ func TestCreateTestDatabase(t *testing.T) {
 
 	volumeID := "test-volume-id"
 	libraryID := "test-library-id"
-	err = db.LinkVolume(libraryID, volumeID)
-	require.NoError(t, err)
+	require.NoError(t, db.AddLibrary(libraryID, "dd-lib-java-init", 0))
+	require.NoError(t, db.LinkVolume(libraryID, volumeID))
 }
 ```

--- a/pkg/metrics/library_listener.go
+++ b/pkg/metrics/library_listener.go
@@ -1,0 +1,84 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
+)
+
+// LibraryListener publishes Datadog CSI driver Prometheus metrics in response
+// to LibraryManager lifecycle events. It implements librarymanager.EventListener;
+// the librarymanager package itself does not depend on this package, which
+// keeps the manager's domain logic free from any observability backend.
+//
+// The listener is stateless: every gauge value it sets is computed by the
+// LibraryManager's database from its in-memory aggregates. This makes it
+// safe for concurrent use and trivially replaceable in tests.
+type LibraryListener struct{}
+
+// NewLibraryListener constructs a LibraryListener ready to be passed to
+// librarymanager.WithEventListener.
+func NewLibraryListener() *LibraryListener {
+	return &LibraryListener{}
+}
+
+// OnLibraryResolved publishes the resolution outcome counter. The underlying
+// string values of librarymanager.LibraryResolutionResult and this package's
+// ResolutionResult are kept in sync so the conversion is a no-op cast.
+func (*LibraryListener) OnLibraryResolved(result librarymanager.LibraryResolutionResult) {
+	RecordLibraryResolution(ResolutionResult(result))
+}
+
+// OnLibraryDownload observes the download duration histogram.
+func (*LibraryListener) OnLibraryDownload(library, registry string, duration time.Duration) {
+	ObserveLibraryDownloadDuration(library, registry, duration)
+}
+
+// OnLibraryCleanup publishes the cleanup outcome counter.
+func (*LibraryListener) OnLibraryCleanup(status librarymanager.LibraryCleanupStatus, strategy string) {
+	RecordLibraryCleanup(CleanupStatus(status), strategy)
+}
+
+// OnVolumeLinked publishes the post-link library_volume_links value for the
+// affected package. The total is computed by the database and passed in;
+// nothing is recomputed here.
+func (*LibraryListener) OnVolumeLinked(pkg string, packageVolumeLinkCount int) {
+	SetLibraryVolumeLinksForPackage(pkg, packageVolumeLinkCount)
+}
+
+// OnVolumeUnlinked publishes the post-unlink library_volume_links value.
+// Series that drop to zero are kept (set to 0 rather than deleted) so
+// dashboards can observe the "no volumes" state explicitly.
+func (*LibraryListener) OnVolumeUnlinked(pkg string, packageVolumeLinkCount int) {
+	SetLibraryVolumeLinksForPackage(pkg, packageVolumeLinkCount)
+}
+
+// OnLibraryCached publishes the post-cache libraries_cached and
+// libraries_cached_bytes values.
+func (*LibraryListener) OnLibraryCached(pkg string, packageCachedCount int, packageCachedBytes int64) {
+	SetLibrariesCachedForPackage(pkg, packageCachedCount)
+	SetLibrariesCachedBytesForPackage(pkg, packageCachedBytes)
+}
+
+// OnLibraryEvicted publishes the post-eviction libraries_cached and
+// libraries_cached_bytes values. Series that drop to zero are kept at 0
+// (same rationale as OnVolumeUnlinked).
+func (*LibraryListener) OnLibraryEvicted(pkg string, packageCachedCount int, packageCachedBytes int64) {
+	SetLibrariesCachedForPackage(pkg, packageCachedCount)
+	SetLibrariesCachedBytesForPackage(pkg, packageCachedBytes)
+}
+
+// OnSnapshot resets the stateful gauges to match the persisted state at
+// startup. Using the bulk Set helpers ensures any series that disappeared
+// while the driver was down (e.g. a package no longer cached) is cleared
+// rather than left at its pre-restart value.
+func (*LibraryListener) OnSnapshot(volumeLinksByPackage, cachedCountByPackage map[string]int, cachedBytesByPackage map[string]int64) {
+	SetLibraryVolumeLinks(volumeLinksByPackage)
+	SetLibrariesCached(cachedCountByPackage)
+	SetLibrariesCachedBytes(cachedBytesByPackage)
+}

--- a/pkg/metrics/library_listener.go
+++ b/pkg/metrics/library_listener.go
@@ -74,11 +74,20 @@ func (*LibraryListener) OnLibraryEvicted(pkg string, packageCachedCount int, pac
 }
 
 // OnSnapshot resets the stateful gauges to match the persisted state at
-// startup. Using the bulk Set helpers ensures any series that disappeared
-// while the driver was down (e.g. a package no longer cached) is cleared
-// rather than left at its pre-restart value.
-func (*LibraryListener) OnSnapshot(volumeLinksByPackage, cachedCountByPackage map[string]int, cachedBytesByPackage map[string]int64) {
-	SetLibraryVolumeLinks(volumeLinksByPackage)
-	SetLibrariesCached(cachedCountByPackage)
-	SetLibrariesCachedBytes(cachedBytesByPackage)
+// startup. The Reset before each fan-out ensures any series that
+// disappeared while the driver was down (e.g. a package no longer cached)
+// is cleared rather than left at its pre-restart value.
+func (*LibraryListener) OnSnapshot(s librarymanager.Snapshot) {
+	libraryVolumeLinks.Reset()
+	for pkg, n := range s.VolumeLinksByPackage {
+		SetLibraryVolumeLinksForPackage(pkg, n)
+	}
+	librariesCached.Reset()
+	for pkg, n := range s.CachedCountByPackage {
+		SetLibrariesCachedForPackage(pkg, n)
+	}
+	librariesCachedBytes.Reset()
+	for pkg, n := range s.CachedBytesByPackage {
+		SetLibrariesCachedBytesForPackage(pkg, n)
+	}
 }

--- a/pkg/metrics/library_listener_test.go
+++ b/pkg/metrics/library_listener_test.go
@@ -1,0 +1,112 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLibraryListenerImplementsInterface fails to compile if the listener
+// drifts from the interface contract. It does not need to be run.
+func TestLibraryListenerImplementsInterface(t *testing.T) {
+	var _ librarymanager.EventListener = (*LibraryListener)(nil)
+}
+
+func TestLibraryListenerPublishesResolutionAndCleanup(t *testing.T) {
+	libraryResolutions.Reset()
+	libraryCleanup.Reset()
+	libraryDownloadDuration.Reset()
+
+	l := NewLibraryListener()
+
+	l.OnLibraryResolved(librarymanager.LibraryResolutionCacheHit)
+	l.OnLibraryResolved(librarymanager.LibraryResolutionDownloaded)
+	l.OnLibraryResolved(librarymanager.LibraryResolutionFailed)
+	l.OnLibraryCleanup(librarymanager.LibraryCleanupSuccess, "immediate")
+	l.OnLibraryCleanup(librarymanager.LibraryCleanupSkippedInUse, "delayed")
+	l.OnLibraryDownload("dd-lib-java-init", "gcr.io", 250*time.Millisecond)
+
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionCacheHit))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionDownloaded))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionFailed))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(CleanupSuccess), "immediate")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(CleanupSkippedInUse), "delayed")))
+
+	// The download histogram is still populated; we just check the sample count
+	// exists for the right labels (bucket layout is tested elsewhere).
+	require.Equal(t, 1, testutil.CollectAndCount(libraryDownloadDuration))
+}
+
+func TestLibraryListenerPublishesVolumeLinkGauge(t *testing.T) {
+	libraryVolumeLinks.Reset()
+
+	l := NewLibraryListener()
+
+	l.OnVolumeLinked("dd-lib-java-init", 3)
+	l.OnVolumeLinked("dd-lib-php-init", 1)
+	require.Equal(t, float64(3), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-php-init")))
+
+	// OnVolumeUnlinked must publish the new count, including zero, so the
+	// "no volumes" state is observable rather than dropped.
+	l.OnVolumeUnlinked("dd-lib-php-init", 0)
+	require.Equal(t, float64(0), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-php-init")))
+	require.Equal(t, 2, testutil.CollectAndCount(libraryVolumeLinks), "zero-valued series must be kept")
+}
+
+func TestLibraryListenerPublishesCachedGauges(t *testing.T) {
+	librariesCached.Reset()
+	librariesCachedBytes.Reset()
+
+	l := NewLibraryListener()
+
+	l.OnLibraryCached("dd-lib-java-init", 2, 1_500_000)
+	l.OnLibraryCached("dd-lib-php-init", 1, 500_000)
+	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1_500_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")))
+	require.Equal(t, float64(500_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")))
+
+	// Eviction down to zero must still publish (kept-at-zero contract).
+	l.OnLibraryEvicted("dd-lib-php-init", 0, 0)
+	require.Equal(t, float64(0), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")))
+	require.Equal(t, float64(0), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")))
+}
+
+func TestLibraryListenerOnSnapshotResetsGauges(t *testing.T) {
+	libraryVolumeLinks.Reset()
+	librariesCached.Reset()
+	librariesCachedBytes.Reset()
+
+	l := NewLibraryListener()
+
+	// Populate a couple of series to simulate the gauge state inherited
+	// from a previous publishing cycle.
+	l.OnVolumeLinked("dd-lib-java-init", 3)
+	l.OnVolumeLinked("stale-package", 7)
+	l.OnLibraryCached("dd-lib-java-init", 2, 1_500_000)
+	l.OnLibraryCached("stale-package", 4, 9_999)
+
+	// A snapshot that no longer mentions "stale-package" must drop it from
+	// every gauge while bringing the kept series back to the snapshot value.
+	l.OnSnapshot(
+		map[string]int{"dd-lib-java-init": 5},
+		map[string]int{"dd-lib-java-init": 1},
+		map[string]int64{"dd-lib-java-init": 42},
+	)
+
+	require.Equal(t, float64(5), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(42), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks), "stale series must be cleared")
+	require.Equal(t, 1, testutil.CollectAndCount(librariesCached), "stale series must be cleared")
+	require.Equal(t, 1, testutil.CollectAndCount(librariesCachedBytes), "stale series must be cleared")
+}

--- a/pkg/metrics/library_listener_test.go
+++ b/pkg/metrics/library_listener_test.go
@@ -97,11 +97,11 @@ func TestLibraryListenerOnSnapshotResetsGauges(t *testing.T) {
 
 	// A snapshot that no longer mentions "stale-package" must drop it from
 	// every gauge while bringing the kept series back to the snapshot value.
-	l.OnSnapshot(
-		map[string]int{"dd-lib-java-init": 5},
-		map[string]int{"dd-lib-java-init": 1},
-		map[string]int64{"dd-lib-java-init": 42},
-	)
+	l.OnSnapshot(librarymanager.Snapshot{
+		VolumeLinksByPackage: map[string]int{"dd-lib-java-init": 5},
+		CachedCountByPackage: map[string]int{"dd-lib-java-init": 1},
+		CachedBytesByPackage: map[string]int64{"dd-lib-java-init": 42},
+	})
 
 	require.Equal(t, float64(5), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
 	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,6 +6,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -27,10 +29,46 @@ const (
 	StatusUnsupported = "unsupported"
 )
 
+// ResolutionResult represents the outcome of attempting to resolve a library for a volume.
+type ResolutionResult string
+
+const (
+	// ResolutionCacheHit indicates the library was already present in the local store.
+	ResolutionCacheHit ResolutionResult = "cache_hit"
+	// ResolutionDownloaded indicates the library was downloaded from the registry.
+	ResolutionDownloaded ResolutionResult = "downloaded"
+	// ResolutionFailed indicates the resolution failed at any step.
+	ResolutionFailed ResolutionResult = "failed"
+)
+
+// CleanupStatus represents the outcome of a library cleanup attempt.
+type CleanupStatus string
+
+const (
+	// CleanupSuccess indicates the library was successfully removed from disk.
+	CleanupSuccess CleanupStatus = "success"
+	// CleanupFailed indicates the cleanup attempt failed.
+	CleanupFailed CleanupStatus = "failed"
+	// CleanupSkippedInUse indicates the cleanup was skipped because the library is still in use.
+	CleanupSkippedInUse CleanupStatus = "skipped_in_use"
+)
+
+// downloadDurationBuckets covers the range from very fast cached/local downloads
+// (~100ms) up to slow registry pulls (~5 minutes).
+var downloadDurationBuckets = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300}
+
 func newCounterVec(name, help string, labels ...string) *prometheus.CounterVec {
 	return prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: subsystem + separator + name,
 		Help: help,
+	}, labels)
+}
+
+func newHistogramVec(name, help string, buckets []float64, labels ...string) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    subsystem + separator + name,
+		Help:    help,
+		Buckets: buckets,
 	}, labels)
 }
 
@@ -48,9 +86,33 @@ var nodeVolumeUnmountAttempts = newCounterVec(
 	"status",
 )
 
+var libraryResolutions = newCounterVec(
+	"library_resolutions_total",
+	"Counts the outcome of attempts to resolve a library for a volume",
+	"result",
+)
+
+var libraryDownloadDuration = newHistogramVec(
+	"library_download_duration_seconds",
+	"Time spent downloading a library from the registry",
+	downloadDurationBuckets,
+	"library",
+	"registry",
+)
+
+var libraryCleanup = newCounterVec(
+	"library_cleanup_total",
+	"Counts cleanup attempts for unused libraries",
+	"status",
+	"strategy",
+)
+
 func init() {
 	prometheus.MustRegister(nodeVolumeMountAttempts)
 	prometheus.MustRegister(nodeVolumeUnmountAttempts)
+	prometheus.MustRegister(libraryResolutions)
+	prometheus.MustRegister(libraryDownloadDuration)
+	prometheus.MustRegister(libraryCleanup)
 }
 
 // RecordVolumeMountAttempt records a volume mount attempt
@@ -61,4 +123,21 @@ func RecordVolumeMountAttempt(volumeType, path string, status Status) {
 // RecordVolumeUnMountAttempt records a volume unmount attempt
 func RecordVolumeUnMountAttempt(status Status) {
 	nodeVolumeUnmountAttempts.WithLabelValues(string(status)).Inc()
+}
+
+// RecordLibraryResolution records the outcome of an attempt to resolve a library for a volume.
+func RecordLibraryResolution(result ResolutionResult) {
+	libraryResolutions.WithLabelValues(string(result)).Inc()
+}
+
+// ObserveLibraryDownloadDuration records the duration of a successful library download.
+// The library and registry labels allow breaking down latency per package and per registry endpoint.
+func ObserveLibraryDownloadDuration(library, registry string, d time.Duration) {
+	libraryDownloadDuration.WithLabelValues(library, registry).Observe(d.Seconds())
+}
+
+// RecordLibraryCleanup records the outcome of a cleanup attempt for an unused library.
+// The strategy label captures which cleanup policy was active (e.g. "immediate", "delayed").
+func RecordLibraryCleanup(status CleanupStatus, strategy string) {
+	libraryCleanup.WithLabelValues(string(status), strategy).Inc()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -174,81 +174,22 @@ func RecordLibraryCleanup(status CleanupStatus, strategy string) {
 // typically for entries persisted by an older driver version.
 const UnknownLibrary = "unknown"
 
-// SetLibraryVolumeLinks replaces the full set of library_volume_links series with
-// the provided counts. Packages missing from counts are removed from the gauge so
-// stale series do not linger after a library becomes unused.
-// Empty package names are reported under "unknown".
-//
-// This performs a Reset followed by a Set per entry, which is acceptable at
-// startup but should be avoided on the hot path because a concurrent scrape
-// could observe a transient empty state. Prefer SetLibraryVolumeLinksForPackage
-// / DeleteLibraryVolumeLinksForPackage to update a single series.
-func SetLibraryVolumeLinks(countsByPackage map[string]int) {
-	libraryVolumeLinks.Reset()
-	for pkg, n := range countsByPackage {
-		libraryVolumeLinks.WithLabelValues(libraryLabel(pkg)).Set(float64(n))
-	}
-}
-
-// SetLibraryVolumeLinksForPackage sets the gauge value for a single package without
-// touching the other series, which is safe to call from the request hot path.
-// Empty package names are reported under "unknown".
+// SetLibraryVolumeLinksForPackage sets the library_volume_links gauge for a
+// single package. Empty package names are reported under "unknown".
 func SetLibraryVolumeLinksForPackage(library string, n int) {
 	libraryVolumeLinks.WithLabelValues(libraryLabel(library)).Set(float64(n))
 }
 
-// DeleteLibraryVolumeLinksForPackage removes the series for a single package.
-// The normal lifecycle keeps zero-valued series (see metricsTracker) so that
-// the "no volumes" state is observable; this helper is reserved for explicit
-// cleanups, e.g. when the library is purged from disk and we no longer want
-// to report on it at all.
-func DeleteLibraryVolumeLinksForPackage(library string) {
-	libraryVolumeLinks.DeleteLabelValues(libraryLabel(library))
-}
-
-// SetLibrariesCached replaces the full set of libraries_cached series with the
-// provided counts. See SetLibraryVolumeLinks for the same caveats around the
-// transient empty state during the Reset; prefer the per-package helpers on
-// the hot path.
-func SetLibrariesCached(countsByPackage map[string]int) {
-	librariesCached.Reset()
-	for pkg, n := range countsByPackage {
-		librariesCached.WithLabelValues(libraryLabel(pkg)).Set(float64(n))
-	}
-}
-
-// SetLibrariesCachedForPackage sets the libraries_cached gauge value for a
-// single package without touching the other series.
+// SetLibrariesCachedForPackage sets the libraries_cached gauge for a single
+// package. Empty package names are reported under "unknown".
 func SetLibrariesCachedForPackage(library string, n int) {
 	librariesCached.WithLabelValues(libraryLabel(library)).Set(float64(n))
 }
 
-// DeleteLibrariesCachedForPackage removes the libraries_cached series for a
-// single package. Like DeleteLibraryVolumeLinksForPackage, this is reserved
-// for explicit cleanups; the normal lifecycle keeps zero-valued series.
-func DeleteLibrariesCachedForPackage(library string) {
-	librariesCached.DeleteLabelValues(libraryLabel(library))
-}
-
-// SetLibrariesCachedBytes replaces the full set of libraries_cached_bytes
-// series with the provided byte totals. See SetLibrariesCached for caveats.
-func SetLibrariesCachedBytes(bytesByPackage map[string]int64) {
-	librariesCachedBytes.Reset()
-	for pkg, n := range bytesByPackage {
-		librariesCachedBytes.WithLabelValues(libraryLabel(pkg)).Set(float64(n))
-	}
-}
-
 // SetLibrariesCachedBytesForPackage sets the libraries_cached_bytes gauge
-// value for a single package without touching the other series.
+// for a single package. Empty package names are reported under "unknown".
 func SetLibrariesCachedBytesForPackage(library string, sizeBytes int64) {
 	librariesCachedBytes.WithLabelValues(libraryLabel(library)).Set(float64(sizeBytes))
-}
-
-// DeleteLibrariesCachedBytesForPackage removes the libraries_cached_bytes
-// series for a single package. Reserved for explicit cleanups.
-func DeleteLibrariesCachedBytesForPackage(library string) {
-	librariesCachedBytes.DeleteLabelValues(libraryLabel(library))
 }
 
 // libraryLabel maps an empty package name to the "unknown" sentinel used for

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -72,6 +72,13 @@ func newHistogramVec(name, help string, buckets []float64, labels ...string) *pr
 	}, labels)
 }
 
+func newGaugeVec(name, help string, labels ...string) *prometheus.GaugeVec {
+	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: subsystem + separator + name,
+		Help: help,
+	}, labels)
+}
+
 var nodeVolumeMountAttempts = newCounterVec(
 	"node_publish_volume_attempts",
 	"Counts the number of publish volume requests received by the csi node server",
@@ -107,12 +114,33 @@ var libraryCleanup = newCounterVec(
 	"strategy",
 )
 
+var libraryVolumeLinks = newGaugeVec(
+	"library_volume_links",
+	"Number of volumes currently linked to each library package",
+	"library",
+)
+
+var librariesCached = newGaugeVec(
+	"libraries_cached",
+	"Number of library versions currently cached on disk for each package",
+	"library",
+)
+
+var librariesCachedBytes = newGaugeVec(
+	"libraries_cached_bytes",
+	"Total size in bytes of the library versions currently cached on disk for each package",
+	"library",
+)
+
 func init() {
 	prometheus.MustRegister(nodeVolumeMountAttempts)
 	prometheus.MustRegister(nodeVolumeUnmountAttempts)
 	prometheus.MustRegister(libraryResolutions)
 	prometheus.MustRegister(libraryDownloadDuration)
 	prometheus.MustRegister(libraryCleanup)
+	prometheus.MustRegister(libraryVolumeLinks)
+	prometheus.MustRegister(librariesCached)
+	prometheus.MustRegister(librariesCachedBytes)
 }
 
 // RecordVolumeMountAttempt records a volume mount attempt
@@ -140,4 +168,94 @@ func ObserveLibraryDownloadDuration(library, registry string, d time.Duration) {
 // The strategy label captures which cleanup policy was active (e.g. "immediate", "delayed").
 func RecordLibraryCleanup(status CleanupStatus, strategy string) {
 	libraryCleanup.WithLabelValues(string(status), strategy).Inc()
+}
+
+// UnknownLibrary is used as the library label when the package cannot be determined,
+// typically for entries persisted by an older driver version.
+const UnknownLibrary = "unknown"
+
+// SetLibraryVolumeLinks replaces the full set of library_volume_links series with
+// the provided counts. Packages missing from counts are removed from the gauge so
+// stale series do not linger after a library becomes unused.
+// Empty package names are reported under "unknown".
+//
+// This performs a Reset followed by a Set per entry, which is acceptable at
+// startup but should be avoided on the hot path because a concurrent scrape
+// could observe a transient empty state. Prefer SetLibraryVolumeLinksForPackage
+// / DeleteLibraryVolumeLinksForPackage to update a single series.
+func SetLibraryVolumeLinks(countsByPackage map[string]int) {
+	libraryVolumeLinks.Reset()
+	for pkg, n := range countsByPackage {
+		libraryVolumeLinks.WithLabelValues(libraryLabel(pkg)).Set(float64(n))
+	}
+}
+
+// SetLibraryVolumeLinksForPackage sets the gauge value for a single package without
+// touching the other series, which is safe to call from the request hot path.
+// Empty package names are reported under "unknown".
+func SetLibraryVolumeLinksForPackage(library string, n int) {
+	libraryVolumeLinks.WithLabelValues(libraryLabel(library)).Set(float64(n))
+}
+
+// DeleteLibraryVolumeLinksForPackage removes the series for a single package.
+// The normal lifecycle keeps zero-valued series (see metricsTracker) so that
+// the "no volumes" state is observable; this helper is reserved for explicit
+// cleanups, e.g. when the library is purged from disk and we no longer want
+// to report on it at all.
+func DeleteLibraryVolumeLinksForPackage(library string) {
+	libraryVolumeLinks.DeleteLabelValues(libraryLabel(library))
+}
+
+// SetLibrariesCached replaces the full set of libraries_cached series with the
+// provided counts. See SetLibraryVolumeLinks for the same caveats around the
+// transient empty state during the Reset; prefer the per-package helpers on
+// the hot path.
+func SetLibrariesCached(countsByPackage map[string]int) {
+	librariesCached.Reset()
+	for pkg, n := range countsByPackage {
+		librariesCached.WithLabelValues(libraryLabel(pkg)).Set(float64(n))
+	}
+}
+
+// SetLibrariesCachedForPackage sets the libraries_cached gauge value for a
+// single package without touching the other series.
+func SetLibrariesCachedForPackage(library string, n int) {
+	librariesCached.WithLabelValues(libraryLabel(library)).Set(float64(n))
+}
+
+// DeleteLibrariesCachedForPackage removes the libraries_cached series for a
+// single package. Like DeleteLibraryVolumeLinksForPackage, this is reserved
+// for explicit cleanups; the normal lifecycle keeps zero-valued series.
+func DeleteLibrariesCachedForPackage(library string) {
+	librariesCached.DeleteLabelValues(libraryLabel(library))
+}
+
+// SetLibrariesCachedBytes replaces the full set of libraries_cached_bytes
+// series with the provided byte totals. See SetLibrariesCached for caveats.
+func SetLibrariesCachedBytes(bytesByPackage map[string]int64) {
+	librariesCachedBytes.Reset()
+	for pkg, n := range bytesByPackage {
+		librariesCachedBytes.WithLabelValues(libraryLabel(pkg)).Set(float64(n))
+	}
+}
+
+// SetLibrariesCachedBytesForPackage sets the libraries_cached_bytes gauge
+// value for a single package without touching the other series.
+func SetLibrariesCachedBytesForPackage(library string, sizeBytes int64) {
+	librariesCachedBytes.WithLabelValues(libraryLabel(library)).Set(float64(sizeBytes))
+}
+
+// DeleteLibrariesCachedBytesForPackage removes the libraries_cached_bytes
+// series for a single package. Reserved for explicit cleanups.
+func DeleteLibrariesCachedBytesForPackage(library string) {
+	librariesCachedBytes.DeleteLabelValues(libraryLabel(library))
+}
+
+// libraryLabel maps an empty package name to the "unknown" sentinel used for
+// entries persisted by an older driver version.
+func libraryLabel(pkg string) string {
+	if pkg == "" {
+		return UnknownLibrary
+	}
+	return pkg
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,83 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordLibraryResolution(t *testing.T) {
+	libraryResolutions.Reset()
+
+	RecordLibraryResolution(ResolutionCacheHit)
+	RecordLibraryResolution(ResolutionCacheHit)
+	RecordLibraryResolution(ResolutionDownloaded)
+	RecordLibraryResolution(ResolutionFailed)
+
+	require.Equal(t, float64(2), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionCacheHit))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionDownloaded))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionFailed))))
+}
+
+func TestRecordLibraryCleanup(t *testing.T) {
+	libraryCleanup.Reset()
+
+	RecordLibraryCleanup(CleanupSuccess, "immediate")
+	RecordLibraryCleanup(CleanupSuccess, "immediate")
+	RecordLibraryCleanup(CleanupFailed, "immediate")
+	RecordLibraryCleanup(CleanupSkippedInUse, "delayed")
+
+	require.Equal(t, float64(2), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(CleanupSuccess), "immediate")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(CleanupFailed), "immediate")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(CleanupSkippedInUse), "delayed")))
+}
+
+func TestObserveLibraryDownloadDuration(t *testing.T) {
+	libraryDownloadDuration.Reset()
+
+	ObserveLibraryDownloadDuration("dd-lib-java-init", "gcr.io", 200*time.Millisecond)
+	ObserveLibraryDownloadDuration("dd-lib-java-init", "gcr.io", 3*time.Second)
+	ObserveLibraryDownloadDuration("dd-lib-php-init", "gcr.io", 1*time.Second)
+	ObserveLibraryDownloadDuration("apm-inject", "docker.io", 75*time.Second)
+
+	cases := []struct {
+		library, registry string
+		wantCount         uint64
+		wantSum           float64
+	}{
+		{"dd-lib-java-init", "gcr.io", 2, 3.2},
+		{"dd-lib-php-init", "gcr.io", 1, 1.0},
+		{"apm-inject", "docker.io", 1, 75.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.library+"_"+tc.registry, func(t *testing.T) {
+			count, sum := histogramCountAndSum(t, libraryDownloadDuration, tc.library, tc.registry)
+			require.Equal(t, tc.wantCount, count)
+			require.InDelta(t, tc.wantSum, sum, 1e-9)
+		})
+	}
+}
+
+// histogramCountAndSum returns the observed sample count and sum for the given
+// (library, registry) series of a HistogramVec. This intentionally ignores
+// bucket layout so the test stays robust when buckets evolve.
+func histogramCountAndSum(t *testing.T, vec *prometheus.HistogramVec, lvs ...string) (uint64, float64) {
+	t.Helper()
+	m, err := vec.GetMetricWithLabelValues(lvs...)
+	require.NoError(t, err)
+
+	pb := &dto.Metric{}
+	require.NoError(t, m.(prometheus.Histogram).Write(pb))
+	require.NotNil(t, pb.Histogram, "metric is not a histogram")
+
+	return pb.Histogram.GetSampleCount(), pb.Histogram.GetSampleSum()
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -28,6 +28,165 @@ func TestRecordLibraryResolution(t *testing.T) {
 	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionFailed))))
 }
 
+func TestSetLibraryVolumeLinks(t *testing.T) {
+	libraryVolumeLinks.Reset()
+
+	SetLibraryVolumeLinks(map[string]int{
+		"dd-lib-java-init": 3,
+		"dd-lib-php-init":  1,
+		"":                 2, // legacy entries without a persisted package
+	})
+
+	require.Equal(t, float64(3), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-php-init")))
+	require.Equal(t, float64(2), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues(UnknownLibrary)))
+
+	// A subsequent call replaces stale series instead of leaving them behind.
+	SetLibraryVolumeLinks(map[string]int{"dd-lib-java-init": 5})
+
+	require.Equal(t, float64(5), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks), "stale series must be cleared")
+}
+
+func TestSetLibraryVolumeLinksForPackage(t *testing.T) {
+	libraryVolumeLinks.Reset()
+
+	// Pre-populate two packages to make sure the targeted update only touches one.
+	SetLibraryVolumeLinks(map[string]int{
+		"dd-lib-java-init": 3,
+		"dd-lib-php-init":  1,
+	})
+
+	SetLibraryVolumeLinksForPackage("dd-lib-java-init", 7)
+
+	require.Equal(t, float64(7), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-php-init")), "other series must be untouched")
+	require.Equal(t, 2, testutil.CollectAndCount(libraryVolumeLinks))
+
+	// An empty package name maps to "unknown".
+	SetLibraryVolumeLinksForPackage("", 4)
+	require.Equal(t, float64(4), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues(UnknownLibrary)))
+}
+
+func TestDeleteLibraryVolumeLinksForPackage(t *testing.T) {
+	libraryVolumeLinks.Reset()
+
+	SetLibraryVolumeLinks(map[string]int{
+		"dd-lib-java-init": 3,
+		"dd-lib-php-init":  1,
+	})
+	require.Equal(t, 2, testutil.CollectAndCount(libraryVolumeLinks))
+
+	DeleteLibraryVolumeLinksForPackage("dd-lib-php-init")
+
+	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks), "the deleted series must be gone")
+	require.Equal(t, float64(3), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+
+	// Deleting a missing package is a no-op.
+	DeleteLibraryVolumeLinksForPackage("dd-lib-php-init")
+	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks))
+}
+
+func TestSetLibrariesCached(t *testing.T) {
+	librariesCached.Reset()
+
+	SetLibrariesCached(map[string]int{
+		"dd-lib-java-init": 2,
+		"dd-lib-php-init":  1,
+		"":                 1, // legacy entries without a persisted package
+	})
+
+	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues(UnknownLibrary)))
+
+	// A subsequent call replaces stale series rather than leaving them behind.
+	SetLibrariesCached(map[string]int{"dd-lib-java-init": 4})
+
+	require.Equal(t, float64(4), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, 1, testutil.CollectAndCount(librariesCached), "stale series must be cleared")
+}
+
+func TestSetLibrariesCachedForPackage(t *testing.T) {
+	librariesCached.Reset()
+
+	SetLibrariesCached(map[string]int{
+		"dd-lib-java-init": 2,
+		"dd-lib-php-init":  1,
+	})
+
+	SetLibrariesCachedForPackage("dd-lib-java-init", 5)
+
+	require.Equal(t, float64(5), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")), "other series must be untouched")
+	require.Equal(t, 2, testutil.CollectAndCount(librariesCached))
+
+	SetLibrariesCachedForPackage("", 3)
+	require.Equal(t, float64(3), testutil.ToFloat64(librariesCached.WithLabelValues(UnknownLibrary)))
+}
+
+func TestDeleteLibrariesCachedForPackage(t *testing.T) {
+	librariesCached.Reset()
+
+	SetLibrariesCached(map[string]int{
+		"dd-lib-java-init": 2,
+		"dd-lib-php-init":  1,
+	})
+	require.Equal(t, 2, testutil.CollectAndCount(librariesCached))
+
+	DeleteLibrariesCachedForPackage("dd-lib-php-init")
+
+	require.Equal(t, 1, testutil.CollectAndCount(librariesCached), "the deleted series must be gone")
+	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+}
+
+func TestSetLibrariesCachedBytes(t *testing.T) {
+	librariesCachedBytes.Reset()
+
+	SetLibrariesCachedBytes(map[string]int64{
+		"dd-lib-java-init": 1_000_000,
+		"dd-lib-php-init":  500_000,
+	})
+
+	require.Equal(t, float64(1_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(500_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")))
+
+	SetLibrariesCachedBytes(map[string]int64{"dd-lib-java-init": 2_000_000})
+	require.Equal(t, float64(2_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, 1, testutil.CollectAndCount(librariesCachedBytes), "stale series must be cleared")
+}
+
+func TestSetLibrariesCachedBytesForPackage(t *testing.T) {
+	librariesCachedBytes.Reset()
+
+	SetLibrariesCachedBytes(map[string]int64{
+		"dd-lib-java-init": 1_000_000,
+		"dd-lib-php-init":  500_000,
+	})
+
+	SetLibrariesCachedBytesForPackage("dd-lib-java-init", 3_000_000)
+	require.Equal(t, float64(3_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(500_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")), "other series must be untouched")
+
+	SetLibrariesCachedBytesForPackage("", 42)
+	require.Equal(t, float64(42), testutil.ToFloat64(librariesCachedBytes.WithLabelValues(UnknownLibrary)))
+}
+
+func TestDeleteLibrariesCachedBytesForPackage(t *testing.T) {
+	librariesCachedBytes.Reset()
+
+	SetLibrariesCachedBytes(map[string]int64{
+		"dd-lib-java-init": 1_000_000,
+		"dd-lib-php-init":  500_000,
+	})
+	require.Equal(t, 2, testutil.CollectAndCount(librariesCachedBytes))
+
+	DeleteLibrariesCachedBytesForPackage("dd-lib-php-init")
+
+	require.Equal(t, 1, testutil.CollectAndCount(librariesCachedBytes), "the deleted series must be gone")
+	require.Equal(t, float64(1_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+}
+
 func TestRecordLibraryCleanup(t *testing.T) {
 	libraryCleanup.Reset()
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -28,163 +28,43 @@ func TestRecordLibraryResolution(t *testing.T) {
 	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(ResolutionFailed))))
 }
 
-func TestSetLibraryVolumeLinks(t *testing.T) {
-	libraryVolumeLinks.Reset()
-
-	SetLibraryVolumeLinks(map[string]int{
-		"dd-lib-java-init": 3,
-		"dd-lib-php-init":  1,
-		"":                 2, // legacy entries without a persisted package
-	})
-
-	require.Equal(t, float64(3), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-php-init")))
-	require.Equal(t, float64(2), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues(UnknownLibrary)))
-
-	// A subsequent call replaces stale series instead of leaving them behind.
-	SetLibraryVolumeLinks(map[string]int{"dd-lib-java-init": 5})
-
-	require.Equal(t, float64(5), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
-	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks), "stale series must be cleared")
-}
-
 func TestSetLibraryVolumeLinksForPackage(t *testing.T) {
 	libraryVolumeLinks.Reset()
 
-	// Pre-populate two packages to make sure the targeted update only touches one.
-	SetLibraryVolumeLinks(map[string]int{
-		"dd-lib-java-init": 3,
-		"dd-lib-php-init":  1,
-	})
-
-	SetLibraryVolumeLinksForPackage("dd-lib-java-init", 7)
+	SetLibraryVolumeLinksForPackage("dd-lib-java-init", 3)
+	SetLibraryVolumeLinksForPackage("dd-lib-php-init", 1)
+	SetLibraryVolumeLinksForPackage("dd-lib-java-init", 7) // overwrites the previous value
+	SetLibraryVolumeLinksForPackage("", 4)                 // empty package maps to "unknown"
 
 	require.Equal(t, float64(7), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
 	require.Equal(t, float64(1), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-php-init")), "other series must be untouched")
-	require.Equal(t, 2, testutil.CollectAndCount(libraryVolumeLinks))
-
-	// An empty package name maps to "unknown".
-	SetLibraryVolumeLinksForPackage("", 4)
 	require.Equal(t, float64(4), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues(UnknownLibrary)))
-}
-
-func TestDeleteLibraryVolumeLinksForPackage(t *testing.T) {
-	libraryVolumeLinks.Reset()
-
-	SetLibraryVolumeLinks(map[string]int{
-		"dd-lib-java-init": 3,
-		"dd-lib-php-init":  1,
-	})
-	require.Equal(t, 2, testutil.CollectAndCount(libraryVolumeLinks))
-
-	DeleteLibraryVolumeLinksForPackage("dd-lib-php-init")
-
-	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks), "the deleted series must be gone")
-	require.Equal(t, float64(3), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
-
-	// Deleting a missing package is a no-op.
-	DeleteLibraryVolumeLinksForPackage("dd-lib-php-init")
-	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks))
-}
-
-func TestSetLibrariesCached(t *testing.T) {
-	librariesCached.Reset()
-
-	SetLibrariesCached(map[string]int{
-		"dd-lib-java-init": 2,
-		"dd-lib-php-init":  1,
-		"":                 1, // legacy entries without a persisted package
-	})
-
-	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
-	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")))
-	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues(UnknownLibrary)))
-
-	// A subsequent call replaces stale series rather than leaving them behind.
-	SetLibrariesCached(map[string]int{"dd-lib-java-init": 4})
-
-	require.Equal(t, float64(4), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
-	require.Equal(t, 1, testutil.CollectAndCount(librariesCached), "stale series must be cleared")
 }
 
 func TestSetLibrariesCachedForPackage(t *testing.T) {
 	librariesCached.Reset()
 
-	SetLibrariesCached(map[string]int{
-		"dd-lib-java-init": 2,
-		"dd-lib-php-init":  1,
-	})
-
+	SetLibrariesCachedForPackage("dd-lib-java-init", 2)
+	SetLibrariesCachedForPackage("dd-lib-php-init", 1)
 	SetLibrariesCachedForPackage("dd-lib-java-init", 5)
+	SetLibrariesCachedForPackage("", 3)
 
 	require.Equal(t, float64(5), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
 	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")), "other series must be untouched")
-	require.Equal(t, 2, testutil.CollectAndCount(librariesCached))
-
-	SetLibrariesCachedForPackage("", 3)
 	require.Equal(t, float64(3), testutil.ToFloat64(librariesCached.WithLabelValues(UnknownLibrary)))
-}
-
-func TestDeleteLibrariesCachedForPackage(t *testing.T) {
-	librariesCached.Reset()
-
-	SetLibrariesCached(map[string]int{
-		"dd-lib-java-init": 2,
-		"dd-lib-php-init":  1,
-	})
-	require.Equal(t, 2, testutil.CollectAndCount(librariesCached))
-
-	DeleteLibrariesCachedForPackage("dd-lib-php-init")
-
-	require.Equal(t, 1, testutil.CollectAndCount(librariesCached), "the deleted series must be gone")
-	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
-}
-
-func TestSetLibrariesCachedBytes(t *testing.T) {
-	librariesCachedBytes.Reset()
-
-	SetLibrariesCachedBytes(map[string]int64{
-		"dd-lib-java-init": 1_000_000,
-		"dd-lib-php-init":  500_000,
-	})
-
-	require.Equal(t, float64(1_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
-	require.Equal(t, float64(500_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")))
-
-	SetLibrariesCachedBytes(map[string]int64{"dd-lib-java-init": 2_000_000})
-	require.Equal(t, float64(2_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
-	require.Equal(t, 1, testutil.CollectAndCount(librariesCachedBytes), "stale series must be cleared")
 }
 
 func TestSetLibrariesCachedBytesForPackage(t *testing.T) {
 	librariesCachedBytes.Reset()
 
-	SetLibrariesCachedBytes(map[string]int64{
-		"dd-lib-java-init": 1_000_000,
-		"dd-lib-php-init":  500_000,
-	})
-
+	SetLibrariesCachedBytesForPackage("dd-lib-java-init", 1_000_000)
+	SetLibrariesCachedBytesForPackage("dd-lib-php-init", 500_000)
 	SetLibrariesCachedBytesForPackage("dd-lib-java-init", 3_000_000)
+	SetLibrariesCachedBytesForPackage("", 42)
+
 	require.Equal(t, float64(3_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
 	require.Equal(t, float64(500_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")), "other series must be untouched")
-
-	SetLibrariesCachedBytesForPackage("", 42)
 	require.Equal(t, float64(42), testutil.ToFloat64(librariesCachedBytes.WithLabelValues(UnknownLibrary)))
-}
-
-func TestDeleteLibrariesCachedBytesForPackage(t *testing.T) {
-	librariesCachedBytes.Reset()
-
-	SetLibrariesCachedBytes(map[string]int64{
-		"dd-lib-java-init": 1_000_000,
-		"dd-lib-php-init":  500_000,
-	})
-	require.Equal(t, 2, testutil.CollectAndCount(librariesCachedBytes))
-
-	DeleteLibrariesCachedBytesForPackage("dd-lib-php-init")
-
-	require.Equal(t, 1, testutil.CollectAndCount(librariesCachedBytes), "the deleted series must be gone")
-	require.Equal(t, float64(1_000_000), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
 }
 
 func TestRecordLibraryCleanup(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds the six Prometheus metrics for the SSI library publisher lifecycle defined in the observability RFC, plus the persistence and listener plumbing they need:

**Counters / histogram (stateless)**
- `datadog_csi_driver_library_resolutions_total{result}` — outcome of library resolution attempts: `cache_hit`, `downloaded`, `failed`.
- `datadog_csi_driver_library_download_duration_seconds{library,registry}` — end-to-end download time (HTTP pull + extraction).
- `datadog_csi_driver_library_cleanup_total{status,strategy}` — cleanup attempts for unused libraries: `success`, `failed`, `skipped_in_use`.

**Gauges (stateful, resynced from the database at startup)**
- `datadog_csi_driver_library_volume_links{library}` — number of volumes currently linked to each library package.
- `datadog_csi_driver_libraries_cached{library}` — number of library versions currently cached on disk for each package.
- `datadog_csi_driver_libraries_cached_bytes{library}` — total on-disk size in bytes of those cached versions per package.

Series transitioning to zero are kept (`Set(0)`) so dashboards and monitors can observe the "no volumes" / "nothing cached" state explicitly rather than seeing the series disappear.

### Motivation

Implements the observability requirements from the [CSI + APM SSI observability RFC](https://docs.google.com/document/d/1S-xF7W5bXnDdpc8Djvy2y8OKaf1etbCgPCk5GxTeFrw/edit?pli=1&tab=t.w73jgjh2orwm).

These metrics answer the operational questions the RFC targets:

| Question | Metric |
|---|---|
| Do we serve from the local cache or repeatedly refetch? | `library_resolutions_total` |
| How long do registry pulls take? | `library_download_duration_seconds` |
| Is the cache cleanup lifecycle healthy? | `library_cleanup_total` |
| How many volumes are mounted per package right now? | `library_volume_links` |
| How many library versions are cached, and how much disk do they take? | `libraries_cached`, `libraries_cached_bytes` |

### How it works

The gauges require persisting a small amount of state and decoupling the `librarymanager` from any concrete observability backend:

- **New `library-metadata` bbolt bucket** stores per-library metadata (package name, cache state, payload size). Existing databases are upgraded transparently at startup: the bucket is created empty and re-populated when a library is next downloaded.
- **In-memory aggregates inside `Database`** mirror the bucket so per-package counters (`libraries_cached*`, `library_volume_links`) can be served in O(1) without rescanning bbolt on every mutation. They are seeded from the persisted state at `NewDatabase` and kept in sync under a single mutex held across each `Commit`.
- **`librarymanager.EventListener` interface** decouples the manager from `pkg/metrics`. The manager publishes lifecycle events (`OnVolumeLinked`, `OnLibraryCached`, `OnSnapshot`, …); the production wiring registers `metrics.NewLibraryListener()` which translates them into Prometheus calls. The default listener is a no-op so the manager can invoke it unconditionally.
- **Startup resync** uses `Database.Snapshot()` to seed the stateful gauges via `EventListener.OnSnapshot()` immediately after the manager is constructed, so dashboards reflect reality after a restart without waiting for the first lifecycle event.

### Migration / upgrade behavior

No manual action required. Libraries cached by a pre-upgrade driver carry no metadata and are reported under `library="unknown"` in `library_volume_links` and `libraries_cached*` until they are evicted and re-downloaded.

### Describe your test plan

- **`pkg/metrics`** — per-helper tests cover every label combination and the kept-at-zero policy for gauges. `TestObserveLibraryDownloadDuration` table-tests `count`/`sum` per `(library, registry)` series and is bucket-independent so it stays robust if `downloadDurationBuckets` evolves.
- **`pkg/librarymanager` (database)** — unit tests for `Database.AddLibrary` / `RemoveLibrary` / `LinkVolume` / `UnlinkVolume` / `Snapshot`, including multi-version aggregation under the same package, blank-input validation across every public method, recovery from a missing or corrupted metadata bucket, and idempotency of repeat link / repeat unlink.
- **`pkg/librarymanager` (manager)** — `TestLibraryManagerEventListenerSequence` is an end-to-end test that wires a fake `EventListener` into a real manager backed by a local registry and asserts the full event sequence across a download, a cache hit, a `skipped_in_use` cleanup and a successful eviction. Additional cases cover `RemoveVolume` on a never-linked volume (`NodeUnpublish` after a failed `NodePublish`), the `cleanup=failed` branch (read-only store directory), and option wiring (`WithCleanupStrategy`, `WithEventListener`).
- **`pkg/metrics/library_listener_test.go`** — verifies the listener honors the `EventListener` contract, including that `OnSnapshot` clears stale series that no longer appear in the post-restart snapshot.

Package coverage of `pkg/librarymanager` is now at 85.4% (uncovered branches are predominantly bbolt-internal error paths that would require mocking the storage engine to exercise).