### PR TITLE
Bump golangci-lint to v1.64.8 and fix new lint findings

### DIFF
--- a/.github/workflows/golang-ci-linter.yaml
+++ b/.github/workflows/golang-ci-linter.yaml
@@ -32,6 +32,6 @@ jobs:
       - name: Lint code
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.63.3
+          version: v1.64.8
           only-new-issues: false
           args: ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,9 @@ run:
   timeout: 10m
   modules-download-mode: readonly
   tests: false
-  skip-files:
+
+issues:
+  exclude-files:
     - "testing.go"
     - ".*\\.pb\\.go"
     - ".*\\.gen\\.go"

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -1,3 +1,8 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
 package main
 
 import (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,7 +42,10 @@ func init() {
 	pflag.Parse()
 
 	// Bind flags to viper
-	viper.BindPFlags(pflag.CommandLine)
+	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
+		log.Error("Failed to bind flags to viper", "error", err)
+		os.Exit(1)
+	}
 
 	// Configure env var support
 	// DD_DRIVER_NAME, DD_CSI_ENDPOINT, DD_DSD_HOST_SOCKET_PATH, etc.

--- a/pkg/driver/publishers/doc.go
+++ b/pkg/driver/publishers/doc.go
@@ -15,7 +15,7 @@ Supported volume types are:
   - DSDSocketDirectory: mounts the directory containing the DogStatsD socket.
   - DatadogSocketsDirectory: mounts the directory containing both sockets.
 
-Deprecated: The legacy `mode`/`path` schema is still supported but deprecated.
-Please migrate to using the `type` schema instead.
+Note: the legacy `mode`/`path` schema is still supported but is considered
+obsolete. Callers should migrate to the `type` schema instead.
 */
 package publishers

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -98,7 +98,7 @@ func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("could not start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
 	libraryMappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
@@ -174,7 +174,7 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("could not start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
 	libraryMappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
@@ -249,7 +249,7 @@ func (db *Database) GetVolumeCount(libraryID string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
 	root := tx.Bucket([]byte(LibraryMappingBucket))
@@ -265,10 +265,13 @@ func (db *Database) GetVolumeCount(libraryID string) (int, error) {
 
 	// Count the keys in the bucket.
 	count := 0
-	bkt.ForEach(func(k, v []byte) error {
+	err = bkt.ForEach(func(k, v []byte) error {
 		count++
 		return nil
 	})
+	if err != nil {
+		return 0, fmt.Errorf("could not count volumes for library %s: %w", libraryID, err)
+	}
 
 	// Return number of volumes linked to the bucket.
 	return count, nil
@@ -286,7 +289,7 @@ func (db *Database) GetLibraryForVolume(volumeID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not start transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	// Get the bucket for volume mappings. If it doesn't exist, we have a system level issue.
 	root := tx.Bucket([]byte(VolumeMappingBucket))

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -182,7 +182,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	if err != nil {
 		return "", fmt.Errorf("could not create scratch directory: %w", err)
 	}
-	defer lm.fs.RemoveAll(scratch)
+	defer func() { _ = lm.fs.RemoveAll(scratch) }()
 
 	// Download the library into the scratch space.
 	log.Info("Downloading library", "image", lib.Image())


### PR DESCRIPTION
### What does this PR do?

Bumps `golangci-lint` from v1.63.3 to v1.64.8 and fixes the handful of new findings that surface as a result.

Migrates `skip-files` to the new `issues.exclude-files` schema. Drive-by: missing copyright header on `cmd/logger.go` and a previously-silenced `viper.BindPFlags` error in `cmd/main.go`.

### Motivation

`go.mod` targets Go 1.24, but v1.63.3 predates Go 1.24 support and breaks on parts of the standard library / toolchain. v1.64.x is the first release that lints Go 1.24 code correctly, so the bump is needed regardless of any feature work.

Extracted from #86 so that PR doesn't have to mix lint churn with logic changes.

### Additional Notes

No behavioral change. Largest diff is `defer tx.Rollback()` → `defer func() { _ = tx.Rollback() }()`, which is the canonical idiom for ignoring deferred errors with the new `errcheck` defaults.

### Describe your test plan

- `make lint` is green locally.
- `go build ./... && go test ./...` still pass.
- CI runs the new linter version on this PR itself.