### PR TITLE
[2/3] Add library lifecycle metrics: libraries_cached, libraries_cached_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `--registry-allow-list` flag (env: `DD_REGISTRY_ALLOW_LIST`) for `DatadogLibrary` volumes. When non-empty, only registries in the list are permitted; requests specifying an unlisted registry are rejected. Empty list (default) allows all registries.
-- New Prometheus metrics for library lifecycle observability:
-  - `datadog_csi_driver_library_resolutions_total{result}` (counter): library resolution outcomes (`cache_hit`, `downloaded`, `failed`).
+- New Prometheus metrics for library lifecycle observability (the `library` label is the package name, e.g. `dd-lib-java-init`):
+  - `datadog_csi_driver_library_resolutions_total{library,result}` (counter): library resolution outcomes (`cache_hit`, `downloaded`, `failed`).
   - `datadog_csi_driver_library_download_duration_seconds{library,registry}` (histogram): time spent downloading a library from the registry.
-  - `datadog_csi_driver_library_cleanup_total{status,strategy}` (counter): cleanup attempts for unused libraries (`success`, `failed`, `skipped_in_use`).
-  - `datadog_csi_driver_libraries_cached{library}` (gauge): number of library versions currently stored on disk, per package.
-  - `datadog_csi_driver_libraries_cached_bytes{library}` (gauge): cumulative on-disk size, in bytes, of cached libraries per package.
+  - `datadog_csi_driver_library_cleanup_total{library,status,strategy}` (counter): cleanup attempts for unused libraries (`success`, `failed`, `skipped_in_use`).
+  - `datadog_csi_driver_libraries_cached{library}` (gauge): number of versions currently stored on disk for each library.
+  - `datadog_csi_driver_libraries_cached_bytes{library}` (gauge): cumulative on-disk size, in bytes, of cached versions for each library.
 - New `library-metadata` bucket in the on-disk bbolt database, storing the package name and on-disk size for each cached library. Required to publish per-package gauges across restarts.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `datadog_csi_driver_library_resolutions_total{result}` (counter): library resolution outcomes (`cache_hit`, `downloaded`, `failed`).
   - `datadog_csi_driver_library_download_duration_seconds{library,registry}` (histogram): time spent downloading a library from the registry.
   - `datadog_csi_driver_library_cleanup_total{status,strategy}` (counter): cleanup attempts for unused libraries (`success`, `failed`, `skipped_in_use`).
+  - `datadog_csi_driver_libraries_cached{library}` (gauge): number of library versions currently stored on disk, per package.
+  - `datadog_csi_driver_libraries_cached_bytes{library}` (gauge): cumulative on-disk size, in bytes, of cached libraries per package.
+- New `library-metadata` bucket in the on-disk bbolt database, storing the package name and on-disk size for each cached library. Required to publish per-package gauges across restarts.
 
 ### Changed
 
 - `librarymanager` no longer depends on `pkg/metrics`. Lifecycle events are reported through a new `libraryevents.Listener` interface defined in a dedicated, dependency-free `pkg/libraryevents` package; the metrics-publishing implementation lives in `pkg/metrics` and is wired in `pkg/driver`.
+
+### Notes
+
+- Libraries cached on disk before this release have no metadata recorded; they are not counted in the `libraries_cached*` gauges until they are downloaded again. The bias is expected to be short-lived because the library publisher is not yet in heavy use.
 
 ## [1.2.2] - 2026-04-21
 

--- a/pkg/libraryevents/libraryevents.go
+++ b/pkg/libraryevents/libraryevents.go
@@ -37,13 +37,16 @@ const (
 
 // Snapshot is a consistent view of every aggregate the listener needs to
 // publish gauges at startup. The maps are owned by the caller.
+//
+// The library key is the package name (e.g. "dd-lib-java-init"), matching
+// the "library" label used by the driver's Prometheus metrics.
 type Snapshot struct {
-	// CachedCountByPackage maps each package name to the number of cached
-	// libraries (library IDs) currently on disk for that package.
-	CachedCountByPackage map[string]int
-	// CachedBytesByPackage maps each package name to the cumulative on-disk
-	// size, in bytes, of the cached libraries for that package.
-	CachedBytesByPackage map[string]int64
+	// CachedCountByLibrary maps each library to the number of cached
+	// versions (library IDs) currently on disk for that library.
+	CachedCountByLibrary map[string]int
+	// CachedBytesByLibrary maps each library to the cumulative on-disk
+	// size, in bytes, of the cached versions for that library.
+	CachedBytesByLibrary map[string]int64
 }
 
 // Listener is notified by the library manager of significant lifecycle
@@ -54,11 +57,17 @@ type Snapshot struct {
 // All methods are expected to be quick and non-blocking: they run on the
 // caller goroutine, sometimes under a per-library lock. Implementations
 // that need to do non-trivial work should fan out internally.
+//
+// The library parameter is the package name (e.g. "dd-lib-java-init"),
+// matching the "library" label used by the driver's Prometheus metrics.
+// It may be empty when the manager could not determine the library (for
+// example on invalid inputs, or for legacy entries on disk that predate
+// the metadata bucket); listeners must tolerate that.
 type Listener interface {
 	// OnLibraryResolved is called once a library resolution attempt
 	// finishes. result reflects whether the library was served from the
 	// cache, freshly downloaded, or the resolution failed.
-	OnLibraryResolved(result ResolutionResult)
+	OnLibraryResolved(library string, result ResolutionResult)
 
 	// OnLibraryDownload is called when a library has been fetched from a
 	// registry, with the time spent on the download. Not called on cache
@@ -67,18 +76,18 @@ type Listener interface {
 
 	// OnLibraryCleanup is called for every cleanup attempt, including ones
 	// that were skipped because the library is still in use.
-	OnLibraryCleanup(status CleanupStatus, strategy string)
+	OnLibraryCleanup(library string, status CleanupStatus, strategy string)
 
 	// OnLibraryCached is called when a new library version has been stored
-	// on disk. cachedCount and cachedBytes are the per-package aggregates
+	// on disk. cachedCount and cachedBytes are the per-library aggregates
 	// after the addition, suitable for a Gauge.Set.
-	OnLibraryCached(packageName string, cachedCount int, cachedBytes int64)
+	OnLibraryCached(library string, cachedCount int, cachedBytes int64)
 
-	// OnLibraryEvicted is called when a library has been removed from disk.
-	// cachedCount and cachedBytes are the per-package aggregates after the
-	// removal (zero when the last version is gone), suitable for a
-	// Gauge.Set.
-	OnLibraryEvicted(packageName string, cachedCount int, cachedBytes int64)
+	// OnLibraryEvicted is called when a library has been removed from
+	// disk. cachedCount and cachedBytes are the per-library aggregates
+	// after the removal (zero when the last version is gone), suitable
+	// for a Gauge.Set.
+	OnLibraryEvicted(library string, cachedCount int, cachedBytes int64)
 
 	// OnSnapshot is called once at LibraryManager construction so the
 	// listener can seed its gauges with the persisted state and avoid the
@@ -90,9 +99,9 @@ type Listener interface {
 // configured. It discards every event.
 type NoopListener struct{}
 
-func (NoopListener) OnLibraryResolved(ResolutionResult)              {}
+func (NoopListener) OnLibraryResolved(string, ResolutionResult)      {}
 func (NoopListener) OnLibraryDownload(string, string, time.Duration) {}
-func (NoopListener) OnLibraryCleanup(CleanupStatus, string)          {}
+func (NoopListener) OnLibraryCleanup(string, CleanupStatus, string)  {}
 func (NoopListener) OnLibraryCached(string, int, int64)              {}
 func (NoopListener) OnLibraryEvicted(string, int, int64)             {}
 func (NoopListener) OnSnapshot(Snapshot)                             {}

--- a/pkg/libraryevents/libraryevents.go
+++ b/pkg/libraryevents/libraryevents.go
@@ -35,6 +35,17 @@ const (
 	CleanupSkippedInUse CleanupStatus = "skipped_in_use"
 )
 
+// Snapshot is a consistent view of every aggregate the listener needs to
+// publish gauges at startup. The maps are owned by the caller.
+type Snapshot struct {
+	// CachedCountByPackage maps each package name to the number of cached
+	// libraries (library IDs) currently on disk for that package.
+	CachedCountByPackage map[string]int
+	// CachedBytesByPackage maps each package name to the cumulative on-disk
+	// size, in bytes, of the cached libraries for that package.
+	CachedBytesByPackage map[string]int64
+}
+
 // Listener is notified by the library manager of significant lifecycle
 // events. The default implementation is a no-op (see NoopListener) so the
 // manager can invoke it unconditionally; the production wiring registers
@@ -57,12 +68,31 @@ type Listener interface {
 	// OnLibraryCleanup is called for every cleanup attempt, including ones
 	// that were skipped because the library is still in use.
 	OnLibraryCleanup(status CleanupStatus, strategy string)
+
+	// OnLibraryCached is called when a new library version has been stored
+	// on disk. cachedCount and cachedBytes are the per-package aggregates
+	// after the addition, suitable for a Gauge.Set.
+	OnLibraryCached(packageName string, cachedCount int, cachedBytes int64)
+
+	// OnLibraryEvicted is called when a library has been removed from disk.
+	// cachedCount and cachedBytes are the per-package aggregates after the
+	// removal (zero when the last version is gone), suitable for a
+	// Gauge.Set.
+	OnLibraryEvicted(packageName string, cachedCount int, cachedBytes int64)
+
+	// OnSnapshot is called once at LibraryManager construction so the
+	// listener can seed its gauges with the persisted state and avoid the
+	// cold-start gap until the next event.
+	OnSnapshot(snapshot Snapshot)
 }
 
 // NoopListener is the default Listener used when no observer is
 // configured. It discards every event.
 type NoopListener struct{}
 
-func (NoopListener) OnLibraryResolved(ResolutionResult)             {}
+func (NoopListener) OnLibraryResolved(ResolutionResult)              {}
 func (NoopListener) OnLibraryDownload(string, string, time.Duration) {}
-func (NoopListener) OnLibraryCleanup(CleanupStatus, string)         {}
+func (NoopListener) OnLibraryCleanup(CleanupStatus, string)          {}
+func (NoopListener) OnLibraryCached(string, int, int64)              {}
+func (NoopListener) OnLibraryEvicted(string, int, int64)             {}
+func (NoopListener) OnSnapshot(Snapshot)                             {}

--- a/pkg/librarymanager/archive.go
+++ b/pkg/librarymanager/archive.go
@@ -23,6 +23,10 @@ type ArchiveExtractor struct {
 	dst    string      // Absolute path to destination (needed for symlinks, as afero doesn't support them)
 	dstFs  afero.Afero // BasePathFs rooted at destination
 	format archives.Tar
+
+	// bytesExtracted tracks the cumulative size of regular files written
+	// during Extract. Reset on each Extract call.
+	bytesExtracted int64
 }
 
 // NewArchiveExtractor initializes a new archive extractor.
@@ -42,9 +46,14 @@ func NewArchiveExtractor(afs afero.Afero, src string, dst string) (*ArchiveExtra
 }
 
 // Extract will copy files from the configured source directory inside the archive to the desitnation directory outside
-// of the archive through the reader provided.
-func (fp *ArchiveExtractor) Extract(ctx context.Context, reader io.Reader) error {
-	return fp.format.Extract(ctx, reader, fp.processFile)
+// of the archive through the reader provided. Returns the cumulative size of
+// the regular files written; symlinks and directories are not counted.
+func (fp *ArchiveExtractor) Extract(ctx context.Context, reader io.Reader) (int64, error) {
+	fp.bytesExtracted = 0
+	if err := fp.format.Extract(ctx, reader, fp.processFile); err != nil {
+		return 0, err
+	}
+	return fp.bytesExtracted, nil
 }
 
 // processFile is a helper function that is called for every file extracted.
@@ -109,10 +118,11 @@ func (fp *ArchiveExtractor) processFile(ctx context.Context, f archives.FileInfo
 		}
 		defer out.Close()
 
-		_, err = io.Copy(out, in)
+		n, err := io.Copy(out, in)
 		if err != nil {
 			return fmt.Errorf("could not copy destination file: %w", err)
 		}
+		fp.bytesExtracted += n
 
 		return nil
 	default:

--- a/pkg/librarymanager/archive_test.go
+++ b/pkg/librarymanager/archive_test.go
@@ -70,7 +70,7 @@ func TestExtract(t *testing.T) {
 			ctx := context.Background()
 			ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, test.source, tsd.Path(t))
 			require.NoError(t, err, "could not setup extractor")
-			err = ae.Extract(ctx, f)
+			_, err = ae.Extract(ctx, f)
 			require.NoError(t, err, "could not extract archive")
 
 			// List files in the destination by path.
@@ -109,7 +109,8 @@ func TestExtractSymlink(t *testing.T) {
 	ctx := context.Background()
 	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
 	require.NoError(t, err)
-	require.NoError(t, ae.Extract(ctx, f))
+	_, err = ae.Extract(ctx, f)
+	require.NoError(t, err)
 
 	// Verify symlink was created with correct target
 	linkPath := filepath.Join(tsd.Path(t), "latest")
@@ -158,7 +159,7 @@ func TestExtractSymlinkPathTraversal(t *testing.T) {
 			require.NoError(t, err)
 
 			// Extraction should succeed - malicious paths are normalized, not rejected
-			err = ae.Extract(ctx, f)
+			_, err = ae.Extract(ctx, f)
 			require.NoError(t, err)
 
 			// Verify the symlink was created inside the destination (path was normalized)
@@ -199,7 +200,8 @@ func TestExtractSymlinkIdempotent(t *testing.T) {
 	// First extraction
 	f1, err := os.Open(archivePath)
 	require.NoError(t, err)
-	require.NoError(t, ae.Extract(ctx, f1))
+	_, err = ae.Extract(ctx, f1)
+	require.NoError(t, err)
 	f1.Close()
 
 	// Verify symlink exists
@@ -215,7 +217,8 @@ func TestExtractSymlinkIdempotent(t *testing.T) {
 
 	ae2, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
 	require.NoError(t, err)
-	require.NoError(t, ae2.Extract(ctx, f2), "second extraction should succeed when symlink already exists with same target")
+	_, err = ae2.Extract(ctx, f2)
+	require.NoError(t, err, "second extraction should succeed when symlink already exists with same target")
 }
 
 func TestExtractSymlinkNoTarget(t *testing.T) {
@@ -246,7 +249,7 @@ func TestExtractSymlinkNoTarget(t *testing.T) {
 	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
 	require.NoError(t, err)
 
-	err = ae.Extract(ctx, archive)
+	_, err = ae.Extract(ctx, archive)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "has no target")
 }

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sync"
 
+	"github.com/Datadog/datadog-csi-driver/pkg/libraryevents"
 	"go.etcd.io/bbolt"
 )
 
@@ -22,11 +24,29 @@ const (
 	// VolumeMappingBucket is the bucket to map volumes. Conceptually, the key structure is as follows:
 	//     /volume-mappings/{{ volume_id }}/{{ library_id }}
 	VolumeMappingBucket = "volume-mappings"
+	// LibraryMetadataBucket stores per-library metadata indexed by library_id.
+	// The value is a JSON-encoded libraryMetadata. The bucket is needed
+	// because the package name is otherwise only known at the moment a
+	// library is added to the cache, and is required to publish
+	// per-package gauges after a process restart.
+	LibraryMetadataBucket = "library-metadata"
 )
 
 type linkedVolume struct{}
 
 type linkedLibrary struct{}
+
+// libraryMetadata is the value stored in LibraryMetadataBucket. The struct
+// is kept small on purpose: any field added here must be tolerant to being
+// missing on records produced by older driver versions.
+type libraryMetadata struct {
+	// Package is the canonical package name (e.g. "dd-lib-java-init") that
+	// shares its value across all versions of the same library and is used
+	// as the metric label.
+	Package string `json:"package,omitempty"`
+	// SizeBytes is the on-disk size of the library, in bytes.
+	SizeBytes int64 `json:"size_bytes,omitempty"`
+}
 
 // Database is a wrapper around bbolt with business logic for the library manager.
 //
@@ -47,6 +67,17 @@ type linkedLibrary struct{}
 // compound operations on a per-library basis.
 type Database struct {
 	bbolt *bbolt.DB
+
+	// cacheMu guards the in-memory aggregates below. They are eventually
+	// consistent with the LibraryMetadataBucket: writers take the lock just
+	// before tx.Commit() so callers that only read aggregates never block
+	// long-running bbolt transactions.
+	cacheMu sync.Mutex
+	// cachedLibrariesByPackage counts cached library IDs per package name.
+	cachedLibrariesByPackage map[string]int
+	// cachedBytesByPackage sums the on-disk size of cached libraries per
+	// package name.
+	cachedBytesByPackage map[string]int64
 }
 
 // NewDatabase initializes a new database. If a database file exists, it will re-use the existing file. Call close when
@@ -67,20 +98,227 @@ func NewDatabase(basePath string) (*Database, error) {
 		if err != nil {
 			return fmt.Errorf("failed to create bucket %s: %w", VolumeMappingBucket, err)
 		}
+		_, err = tx.CreateBucketIfNotExists([]byte(LibraryMetadataBucket))
+		if err != nil {
+			return fmt.Errorf("failed to create bucket %s: %w", LibraryMetadataBucket, err)
+		}
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not create initial buckets: %w", err)
 	}
 
-	return &Database{
-		bbolt: db,
-	}, nil
+	database := &Database{
+		bbolt:                    db,
+		cachedLibrariesByPackage: map[string]int{},
+		cachedBytesByPackage:     map[string]int64{},
+	}
+
+	// Seed the in-memory aggregates from the on-disk metadata so the
+	// listener can publish accurate gauges immediately after startup.
+	if err := database.loadCaches(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("could not load caches: %w", err)
+	}
+
+	return database, nil
+}
+
+// loadCaches scans LibraryMetadataBucket once at startup and rebuilds the
+// in-memory aggregates.
+func (db *Database) loadCaches() error {
+	return db.bbolt.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+		if bkt == nil {
+			return nil
+		}
+		return bkt.ForEach(func(_, v []byte) error {
+			var meta libraryMetadata
+			if err := json.Unmarshal(v, &meta); err != nil {
+				return fmt.Errorf("could not unmarshal library metadata: %w", err)
+			}
+			db.cachedLibrariesByPackage[meta.Package]++
+			db.cachedBytesByPackage[meta.Package] += meta.SizeBytes
+			return nil
+		})
+	})
 }
 
 // Close will clean up the database and should be called before exiting.
 func (db *Database) Close() error {
 	return db.bbolt.Close()
+}
+
+// AddLibrary records a freshly-cached library: it persists the metadata
+// (package name + on-disk size) in LibraryMetadataBucket and updates the
+// in-memory aggregates. AddLibrary is the canonical writer for library
+// metadata; LinkVolume relies on it having been called first so that
+// per-package gauges have the right package name.
+//
+// AddLibrary is idempotent: calling it twice for the same library overwrites
+// the previous metadata (useful if the size changed) but does not
+// double-count it in the aggregates.
+func (db *Database) AddLibrary(libraryID, packageName string, sizeBytes int64) error {
+	if libraryID == "" {
+		return fmt.Errorf("library ID cannot be blank")
+	}
+	if packageName == "" {
+		return fmt.Errorf("package name cannot be blank")
+	}
+
+	tx, err := db.bbolt.Begin(true)
+	if err != nil {
+		return fmt.Errorf("could not start transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+	if bkt == nil {
+		return fmt.Errorf("library metadata bucket does not exist")
+	}
+
+	// Preserve idempotency: if the library is already recorded we must
+	// subtract the previous size from the aggregates before adding the
+	// new one.
+	var previous libraryMetadata
+	if raw := bkt.Get([]byte(libraryID)); raw != nil {
+		if err := json.Unmarshal(raw, &previous); err != nil {
+			return fmt.Errorf("could not unmarshal existing library metadata: %w", err)
+		}
+	}
+
+	meta := libraryMetadata{Package: packageName, SizeBytes: sizeBytes}
+	encoded, err := json.Marshal(&meta)
+	if err != nil {
+		return fmt.Errorf("could not marshal library metadata: %w", err)
+	}
+	if err := bkt.Put([]byte(libraryID), encoded); err != nil {
+		return fmt.Errorf("could not write library metadata: %w", err)
+	}
+
+	db.cacheMu.Lock()
+	if previous.Package != "" {
+		db.cachedLibrariesByPackage[previous.Package]--
+		db.cachedBytesByPackage[previous.Package] -= previous.SizeBytes
+		if db.cachedLibrariesByPackage[previous.Package] <= 0 {
+			delete(db.cachedLibrariesByPackage, previous.Package)
+			delete(db.cachedBytesByPackage, previous.Package)
+		}
+	}
+	db.cachedLibrariesByPackage[packageName]++
+	db.cachedBytesByPackage[packageName] += sizeBytes
+	if err := tx.Commit(); err != nil {
+		db.cacheMu.Unlock()
+		return fmt.Errorf("could not commit transaction: %w", err)
+	}
+	db.cacheMu.Unlock()
+
+	return nil
+}
+
+// RemoveLibrary removes the metadata for a library and decrements the
+// in-memory aggregates accordingly. It is a no-op if the library has no
+// metadata recorded.
+func (db *Database) RemoveLibrary(libraryID string) error {
+	if libraryID == "" {
+		return fmt.Errorf("library ID cannot be blank")
+	}
+
+	tx, err := db.bbolt.Begin(true)
+	if err != nil {
+		return fmt.Errorf("could not start transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+	if bkt == nil {
+		return fmt.Errorf("library metadata bucket does not exist")
+	}
+
+	raw := bkt.Get([]byte(libraryID))
+	if raw == nil {
+		return nil
+	}
+	var meta libraryMetadata
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return fmt.Errorf("could not unmarshal library metadata: %w", err)
+	}
+	if err := bkt.Delete([]byte(libraryID)); err != nil {
+		return fmt.Errorf("could not delete library metadata: %w", err)
+	}
+
+	db.cacheMu.Lock()
+	db.cachedLibrariesByPackage[meta.Package]--
+	db.cachedBytesByPackage[meta.Package] -= meta.SizeBytes
+	if db.cachedLibrariesByPackage[meta.Package] <= 0 {
+		delete(db.cachedLibrariesByPackage, meta.Package)
+		delete(db.cachedBytesByPackage, meta.Package)
+	}
+	if err := tx.Commit(); err != nil {
+		db.cacheMu.Unlock()
+		return fmt.Errorf("could not commit transaction: %w", err)
+	}
+	db.cacheMu.Unlock()
+
+	return nil
+}
+
+// PackageCacheStats returns the current cached-library count and the total
+// on-disk size, in bytes, for a given package name. Both values are zero
+// when the package has no cached library.
+func (db *Database) PackageCacheStats(packageName string) (int, int64) {
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	return db.cachedLibrariesByPackage[packageName], db.cachedBytesByPackage[packageName]
+}
+
+// PackageForLibrary returns the package name recorded for a library, or an
+// empty string when the library has no metadata (for instance because it
+// was added by an older driver version that did not yet persist
+// per-library metadata).
+func (db *Database) PackageForLibrary(libraryID string) (string, error) {
+	if libraryID == "" {
+		return "", fmt.Errorf("library ID cannot be blank")
+	}
+
+	var pkg string
+	err := db.bbolt.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+		if bkt == nil {
+			return nil
+		}
+		raw := bkt.Get([]byte(libraryID))
+		if raw == nil {
+			return nil
+		}
+		var meta libraryMetadata
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			return fmt.Errorf("could not unmarshal library metadata: %w", err)
+		}
+		pkg = meta.Package
+		return nil
+	})
+	return pkg, err
+}
+
+// Snapshot returns a consistent snapshot of every aggregate the listener
+// needs to publish gauges. The returned maps are owned by the caller and
+// safe to retain.
+func (db *Database) Snapshot() libraryevents.Snapshot {
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	cachedCount := make(map[string]int, len(db.cachedLibrariesByPackage))
+	for pkg, n := range db.cachedLibrariesByPackage {
+		cachedCount[pkg] = n
+	}
+	cachedBytes := make(map[string]int64, len(db.cachedBytesByPackage))
+	for pkg, n := range db.cachedBytesByPackage {
+		cachedBytes[pkg] = n
+	}
+	return libraryevents.Snapshot{
+		CachedCountByPackage: cachedCount,
+		CachedBytesByPackage: cachedBytes,
+	}
 }
 
 // LinkVolume creates a bidrectional mapping between the library and volume.

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -316,8 +316,8 @@ func (db *Database) Snapshot() libraryevents.Snapshot {
 		cachedBytes[pkg] = n
 	}
 	return libraryevents.Snapshot{
-		CachedCountByPackage: cachedCount,
-		CachedBytesByPackage: cachedBytes,
+		CachedCountByLibrary: cachedCount,
+		CachedBytesByLibrary: cachedBytes,
 	}
 }
 

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -90,3 +90,96 @@ func TestDatabase(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, lib, "there should be no libs linked")
 }
+
+func TestDatabaseLibraryMetadata(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// A package with no cached library reports zero stats and an empty package name.
+	count, bytes := db.PackageCacheStats("unknown")
+	require.Equal(t, 0, count)
+	require.Equal(t, int64(0), bytes)
+
+	pkg, err := db.PackageForLibrary("unknown")
+	require.NoError(t, err)
+	require.Empty(t, pkg)
+
+	// Two versions of the same package aggregate together.
+	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 100))
+	require.NoError(t, db.AddLibrary("lib-id-2", "dd-lib-java-init", 200))
+	count, bytes = db.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 2, count)
+	require.Equal(t, int64(300), bytes)
+
+	pkg, err = db.PackageForLibrary("lib-id-1")
+	require.NoError(t, err)
+	require.Equal(t, "dd-lib-java-init", pkg)
+
+	// AddLibrary on the same library ID is idempotent: it overwrites the
+	// previous record without double-counting.
+	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 150))
+	count, bytes = db.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 2, count)
+	require.Equal(t, int64(350), bytes)
+
+	// A different package is tracked independently.
+	require.NoError(t, db.AddLibrary("php-id", "dd-lib-php-init", 42))
+	snap := db.Snapshot()
+	require.Equal(t, 2, snap.CachedCountByPackage["dd-lib-java-init"])
+	require.Equal(t, int64(350), snap.CachedBytesByPackage["dd-lib-java-init"])
+	require.Equal(t, 1, snap.CachedCountByPackage["dd-lib-php-init"])
+	require.Equal(t, int64(42), snap.CachedBytesByPackage["dd-lib-php-init"])
+
+	// Removing one of two versions keeps the package present.
+	require.NoError(t, db.RemoveLibrary("lib-id-1"))
+	count, bytes = db.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 1, count)
+	require.Equal(t, int64(200), bytes)
+
+	// Removing the last version drops the package entry from the aggregates.
+	require.NoError(t, db.RemoveLibrary("lib-id-2"))
+	count, bytes = db.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 0, count)
+	require.Equal(t, int64(0), bytes)
+
+	// RemoveLibrary is a no-op on an unknown library.
+	require.NoError(t, db.RemoveLibrary("never-existed"))
+}
+
+func TestDatabaseMetadataPersistsAcrossRestart(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 1024))
+	require.NoError(t, db.Close())
+
+	// Reopen and verify the aggregates were rebuilt from the persisted state.
+	db2, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db2.Close()
+
+	count, bytes := db2.PackageCacheStats("dd-lib-java-init")
+	require.Equal(t, 1, count)
+	require.Equal(t, int64(1024), bytes)
+}
+
+func TestDatabaseValidatesBlankInputsForMetadata(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.Error(t, db.AddLibrary("", "pkg", 0))
+	require.Error(t, db.AddLibrary("lib", "", 0))
+	require.Error(t, db.RemoveLibrary(""))
+	_, err = db.PackageForLibrary("")
+	require.Error(t, err)
+}

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -129,10 +129,10 @@ func TestDatabaseLibraryMetadata(t *testing.T) {
 	// A different package is tracked independently.
 	require.NoError(t, db.AddLibrary("php-id", "dd-lib-php-init", 42))
 	snap := db.Snapshot()
-	require.Equal(t, 2, snap.CachedCountByPackage["dd-lib-java-init"])
-	require.Equal(t, int64(350), snap.CachedBytesByPackage["dd-lib-java-init"])
-	require.Equal(t, 1, snap.CachedCountByPackage["dd-lib-php-init"])
-	require.Equal(t, int64(42), snap.CachedBytesByPackage["dd-lib-php-init"])
+	require.Equal(t, 2, snap.CachedCountByLibrary["dd-lib-java-init"])
+	require.Equal(t, int64(350), snap.CachedBytesByLibrary["dd-lib-java-init"])
+	require.Equal(t, 1, snap.CachedCountByLibrary["dd-lib-php-init"])
+	require.Equal(t, int64(42), snap.CachedBytesByLibrary["dd-lib-php-init"])
 
 	// Removing one of two versions keeps the package present.
 	require.NoError(t, db.RemoveLibrary("lib-id-1"))

--- a/pkg/librarymanager/downloader.go
+++ b/pkg/librarymanager/downloader.go
@@ -41,8 +41,8 @@ func NewDownloaderWithRoundTripper(roundTripper http.RoundTripper) *Downloader {
 }
 
 // Download will stream a container image and extract the source directory from inside of the image to the destination
-// directory on disk.
-func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string, dst string) error {
+// directory on disk. Returns the cumulative size of the regular files written.
+func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string, dst string) (int64, error) {
 	img, err := crane.Pull(image,
 		crane.WithContext(ctx),
 		crane.WithUserAgent(userAgent),
@@ -50,7 +50,7 @@ func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string
 		crane.WithPlatform(&v1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}),
 	)
 	if err != nil {
-		return fmt.Errorf("could not pull %s: %w", image, err)
+		return 0, fmt.Errorf("could not pull %s: %w", image, err)
 	}
 
 	pr, pw := io.Pipe()
@@ -61,14 +61,14 @@ func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string
 	// Extract the entire image content
 	fp, err := NewArchiveExtractor(afs, "/", dst)
 	if err != nil {
-		return fmt.Errorf("could not setup archive extractor: %w", err)
+		return 0, fmt.Errorf("could not setup archive extractor: %w", err)
 	}
-	err = fp.Extract(ctx, pr)
+	bytes, err := fp.Extract(ctx, pr)
 	if err != nil {
-		return fmt.Errorf("could not extract archive: %w", err)
+		return 0, fmt.Errorf("could not extract archive: %w", err)
 	}
 
-	return nil
+	return bytes, nil
 }
 
 // FetchDigest will fetch a sha256 sum of the image and return it.

--- a/pkg/librarymanager/downloader_test.go
+++ b/pkg/librarymanager/downloader_test.go
@@ -54,7 +54,7 @@ func TestDownload(t *testing.T) {
 			require.Equal(t, test.expectedDigest, digest)
 
 			// Ensure downloaded files match the expected.
-			err = d.Download(ctx, afero.Afero{Fs: afero.NewOsFs()}, image, tsd.Path(t))
+			_, err = d.Download(ctx, afero.Afero{Fs: afero.NewOsFs()}, image, tsd.Path(t))
 			require.NoError(t, err, "error found when downloading")
 
 			// Ensure expected files exist.

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -143,6 +143,11 @@ func NewLibraryManager(basePath string, opts ...LibraryManagerOption) (*LibraryM
 	// Setup cache.
 	lm.cache = NewImageCache(lm.downloader, DefaultImageCacheTTL)
 
+	// Seed listener gauges from the persisted state, so dashboards reflect
+	// reality immediately after a driver restart instead of waiting for the
+	// first event.
+	lm.listener.OnSnapshot(lm.db.Snapshot())
+
 	return lm, nil
 }
 
@@ -217,7 +222,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	// Download the library into the scratch space.
 	log.Info("Downloading library", "image", lib.Image())
 	downloadStart := time.Now()
-	err = lm.downloader.Download(ctx, lm.fs, lib.Image(), scratch)
+	sizeBytes, err := lm.downloader.Download(ctx, lm.fs, lib.Image(), scratch)
 	if err != nil {
 		return "", err
 	}
@@ -229,6 +234,17 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return "", err
 	}
 	log.Info("Library downloaded and stored", "image", lib.Image(), "path", storePath)
+
+	// Record the library in the metadata bucket and notify the listener.
+	// AddLibrary is the canonical writer for the per-library metadata; it
+	// must be called before any consumer relies on the package name being
+	// available for the given library ID.
+	if err := lm.db.AddLibrary(libraryID, lib.Name(), sizeBytes); err != nil {
+		return "", fmt.Errorf("could not record library metadata: %w", err)
+	}
+	count, totalBytes := lm.db.PackageCacheStats(lib.Name())
+	lm.listener.OnLibraryCached(lib.Name(), count, totalBytes)
+
 	result = libraryevents.ResolutionDownloaded
 	return storePath, nil
 }
@@ -278,9 +294,29 @@ func (lm *LibraryManager) tryCleanupLibrary(libraryID string) error {
 		return nil
 	}
 	log.Info("Removing library from disk", "library_id", libraryID)
+
+	// Look up the package name before the metadata is wiped so we can
+	// notify the listener with the right gauge label. Older libraries on
+	// disk that predate the metadata bucket return an empty string here;
+	// for those the cached gauges are skipped, since we never tracked them
+	// in the first place.
+	packageName, err := lm.db.PackageForLibrary(libraryID)
+	if err != nil {
+		lm.listener.OnLibraryCleanup(libraryevents.CleanupFailed, strategy)
+		return fmt.Errorf("could not get package for library %s: %w", libraryID, err)
+	}
+
 	if err := lm.store.Remove(libraryID); err != nil {
 		lm.listener.OnLibraryCleanup(libraryevents.CleanupFailed, strategy)
 		return err
+	}
+	if err := lm.db.RemoveLibrary(libraryID); err != nil {
+		lm.listener.OnLibraryCleanup(libraryevents.CleanupFailed, strategy)
+		return fmt.Errorf("could not remove library metadata for %s: %w", libraryID, err)
+	}
+	if packageName != "" {
+		newCount, newBytes := lm.db.PackageCacheStats(packageName)
+		lm.listener.OnLibraryEvicted(packageName, newCount, newBytes)
 	}
 	lm.listener.OnLibraryCleanup(libraryevents.CleanupSuccess, strategy)
 	return nil

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -174,7 +174,11 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	// before returning.
 	result := libraryevents.ResolutionFailed
 	defer func() {
-		lm.listener.OnLibraryResolved(result)
+		library := ""
+		if lib != nil {
+			library = lib.Name()
+		}
+		lm.listener.OnLibraryResolved(library, result)
 	}()
 
 	// Validate the input.
@@ -282,42 +286,42 @@ func (lm *LibraryManager) tryCleanupLibrary(libraryID string) error {
 	lm.locker.Lock(libraryID)
 	defer lm.locker.Unlock(libraryID)
 
+	// Look up the library name up-front so every cleanup event carries the
+	// right label. Older entries on disk that predate the metadata bucket
+	// resolve to an empty string; the cached gauges are skipped for them
+	// (we never tracked them in the first place) but the cleanup counter
+	// is still incremented.
+	library, err := lm.db.PackageForLibrary(libraryID)
+	if err != nil {
+		lm.listener.OnLibraryCleanup("", libraryevents.CleanupFailed, strategy)
+		return fmt.Errorf("could not get library for ID %s: %w", libraryID, err)
+	}
+
 	// Check if the library is still in use
 	count, err := lm.db.GetVolumeCount(libraryID)
 	if err != nil {
-		lm.listener.OnLibraryCleanup(libraryevents.CleanupFailed, strategy)
+		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupFailed, strategy)
 		return fmt.Errorf("could not get linked library count: %w", err)
 	}
 	if count > 0 {
 		log.Info("Library still in use, skipping cleanup", "library_id", libraryID, "count", count)
-		lm.listener.OnLibraryCleanup(libraryevents.CleanupSkippedInUse, strategy)
+		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupSkippedInUse, strategy)
 		return nil
 	}
 	log.Info("Removing library from disk", "library_id", libraryID)
 
-	// Look up the package name before the metadata is wiped so we can
-	// notify the listener with the right gauge label. Older libraries on
-	// disk that predate the metadata bucket return an empty string here;
-	// for those the cached gauges are skipped, since we never tracked them
-	// in the first place.
-	packageName, err := lm.db.PackageForLibrary(libraryID)
-	if err != nil {
-		lm.listener.OnLibraryCleanup(libraryevents.CleanupFailed, strategy)
-		return fmt.Errorf("could not get package for library %s: %w", libraryID, err)
-	}
-
 	if err := lm.store.Remove(libraryID); err != nil {
-		lm.listener.OnLibraryCleanup(libraryevents.CleanupFailed, strategy)
+		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupFailed, strategy)
 		return err
 	}
 	if err := lm.db.RemoveLibrary(libraryID); err != nil {
-		lm.listener.OnLibraryCleanup(libraryevents.CleanupFailed, strategy)
+		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupFailed, strategy)
 		return fmt.Errorf("could not remove library metadata for %s: %w", libraryID, err)
 	}
-	if packageName != "" {
-		newCount, newBytes := lm.db.PackageCacheStats(packageName)
-		lm.listener.OnLibraryEvicted(packageName, newCount, newBytes)
+	if library != "" {
+		newCount, newBytes := lm.db.PackageCacheStats(library)
+		lm.listener.OnLibraryEvicted(library, newCount, newBytes)
 	}
-	lm.listener.OnLibraryCleanup(libraryevents.CleanupSuccess, strategy)
+	lm.listener.OnLibraryCleanup(library, libraryevents.CleanupSuccess, strategy)
 	return nil
 }

--- a/pkg/metrics/library_listener.go
+++ b/pkg/metrics/library_listener.go
@@ -40,3 +40,35 @@ func (*LibraryListener) OnLibraryDownload(library, registry string, duration tim
 func (*LibraryListener) OnLibraryCleanup(status libraryevents.CleanupStatus, strategy string) {
 	RecordLibraryCleanup(status, strategy)
 }
+
+// OnLibraryCached updates the per-package cached gauges with the new
+// aggregate values reported by the manager. The manager guarantees the
+// counts are post-update.
+func (*LibraryListener) OnLibraryCached(packageName string, cachedCount int, cachedBytes int64) {
+	SetLibrariesCachedForPackage(packageName, cachedCount)
+	SetLibrariesCachedBytesForPackage(packageName, cachedBytes)
+}
+
+// OnLibraryEvicted updates the per-package cached gauges with the new
+// aggregate values reported by the manager. When the last version of a
+// package is evicted both counts are zero, which materialises in
+// Prometheus as a series of value 0 (kept intentionally so dashboards can
+// show "cache is empty" rather than gap).
+func (*LibraryListener) OnLibraryEvicted(packageName string, cachedCount int, cachedBytes int64) {
+	SetLibrariesCachedForPackage(packageName, cachedCount)
+	SetLibrariesCachedBytesForPackage(packageName, cachedBytes)
+}
+
+// OnSnapshot seeds the per-package gauges from the persisted state. Reset
+// is used so packages that disappeared between two driver runs are not
+// stuck reporting stale values.
+func (*LibraryListener) OnSnapshot(s libraryevents.Snapshot) {
+	librariesCached.Reset()
+	librariesCachedBytes.Reset()
+	for pkg, count := range s.CachedCountByPackage {
+		SetLibrariesCachedForPackage(pkg, count)
+	}
+	for pkg, bytes := range s.CachedBytesByPackage {
+		SetLibrariesCachedBytesForPackage(pkg, bytes)
+	}
+}

--- a/pkg/metrics/library_listener.go
+++ b/pkg/metrics/library_listener.go
@@ -27,8 +27,8 @@ func NewLibraryListener() *LibraryListener {
 }
 
 // OnLibraryResolved publishes the resolution outcome counter.
-func (*LibraryListener) OnLibraryResolved(result libraryevents.ResolutionResult) {
-	RecordLibraryResolution(result)
+func (*LibraryListener) OnLibraryResolved(library string, result libraryevents.ResolutionResult) {
+	RecordLibraryResolution(library, result)
 }
 
 // OnLibraryDownload observes the download duration histogram.
@@ -37,38 +37,38 @@ func (*LibraryListener) OnLibraryDownload(library, registry string, duration tim
 }
 
 // OnLibraryCleanup publishes the cleanup outcome counter.
-func (*LibraryListener) OnLibraryCleanup(status libraryevents.CleanupStatus, strategy string) {
-	RecordLibraryCleanup(status, strategy)
+func (*LibraryListener) OnLibraryCleanup(library string, status libraryevents.CleanupStatus, strategy string) {
+	RecordLibraryCleanup(library, status, strategy)
 }
 
-// OnLibraryCached updates the per-package cached gauges with the new
+// OnLibraryCached updates the per-library cached gauges with the new
 // aggregate values reported by the manager. The manager guarantees the
 // counts are post-update.
-func (*LibraryListener) OnLibraryCached(packageName string, cachedCount int, cachedBytes int64) {
-	SetLibrariesCachedForPackage(packageName, cachedCount)
-	SetLibrariesCachedBytesForPackage(packageName, cachedBytes)
+func (*LibraryListener) OnLibraryCached(library string, cachedCount int, cachedBytes int64) {
+	SetLibrariesCachedForLibrary(library, cachedCount)
+	SetLibrariesCachedBytesForLibrary(library, cachedBytes)
 }
 
-// OnLibraryEvicted updates the per-package cached gauges with the new
+// OnLibraryEvicted updates the per-library cached gauges with the new
 // aggregate values reported by the manager. When the last version of a
-// package is evicted both counts are zero, which materialises in
+// library is evicted both counts are zero, which materialises in
 // Prometheus as a series of value 0 (kept intentionally so dashboards can
 // show "cache is empty" rather than gap).
-func (*LibraryListener) OnLibraryEvicted(packageName string, cachedCount int, cachedBytes int64) {
-	SetLibrariesCachedForPackage(packageName, cachedCount)
-	SetLibrariesCachedBytesForPackage(packageName, cachedBytes)
+func (*LibraryListener) OnLibraryEvicted(library string, cachedCount int, cachedBytes int64) {
+	SetLibrariesCachedForLibrary(library, cachedCount)
+	SetLibrariesCachedBytesForLibrary(library, cachedBytes)
 }
 
-// OnSnapshot seeds the per-package gauges from the persisted state. Reset
-// is used so packages that disappeared between two driver runs are not
+// OnSnapshot seeds the per-library gauges from the persisted state. Reset
+// is used so libraries that disappeared between two driver runs are not
 // stuck reporting stale values.
 func (*LibraryListener) OnSnapshot(s libraryevents.Snapshot) {
 	librariesCached.Reset()
 	librariesCachedBytes.Reset()
-	for pkg, count := range s.CachedCountByPackage {
-		SetLibrariesCachedForPackage(pkg, count)
+	for library, count := range s.CachedCountByLibrary {
+		SetLibrariesCachedForLibrary(library, count)
 	}
-	for pkg, bytes := range s.CachedBytesByPackage {
-		SetLibrariesCachedBytesForPackage(pkg, bytes)
+	for library, bytes := range s.CachedBytesByLibrary {
+		SetLibrariesCachedBytesForLibrary(library, bytes)
 	}
 }

--- a/pkg/metrics/library_listener_test.go
+++ b/pkg/metrics/library_listener_test.go
@@ -44,3 +44,39 @@ func TestLibraryListenerPublishesResolutionAndCleanup(t *testing.T) {
 	// exists for the right labels (bucket layout is tested elsewhere).
 	require.Equal(t, 1, testutil.CollectAndCount(libraryDownloadDuration))
 }
+
+func TestLibraryListenerCachedAndEvictedSetGauges(t *testing.T) {
+	librariesCached.Reset()
+	librariesCachedBytes.Reset()
+
+	l := NewLibraryListener()
+	l.OnLibraryCached("dd-lib-java-init", 2, 1024)
+	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1024), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+
+	// Evicting back to zero leaves the series at 0 so dashboards do not see a gap.
+	l.OnLibraryEvicted("dd-lib-java-init", 0, 0)
+	require.Equal(t, float64(0), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(0), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+}
+
+func TestLibraryListenerOnSnapshotSeedsGauges(t *testing.T) {
+	librariesCached.Reset()
+	librariesCachedBytes.Reset()
+
+	// Pre-existing stale series should be wiped by Reset inside OnSnapshot.
+	librariesCached.WithLabelValues("stale").Set(7)
+
+	l := NewLibraryListener()
+	l.OnSnapshot(libraryevents.Snapshot{
+		CachedCountByPackage: map[string]int{"dd-lib-java-init": 2, "dd-lib-php-init": 1},
+		CachedBytesByPackage: map[string]int64{"dd-lib-java-init": 4096, "dd-lib-php-init": 64},
+	})
+
+	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(4096), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
+	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")))
+	require.Equal(t, float64(64), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")))
+
+	require.Equal(t, 2, testutil.CollectAndCount(librariesCached), "stale series should be evicted")
+}

--- a/pkg/metrics/library_listener_test.go
+++ b/pkg/metrics/library_listener_test.go
@@ -27,18 +27,18 @@ func TestLibraryListenerPublishesResolutionAndCleanup(t *testing.T) {
 
 	l := NewLibraryListener()
 
-	l.OnLibraryResolved(libraryevents.ResolutionCacheHit)
-	l.OnLibraryResolved(libraryevents.ResolutionDownloaded)
-	l.OnLibraryResolved(libraryevents.ResolutionFailed)
-	l.OnLibraryCleanup(libraryevents.CleanupSuccess, "immediate")
-	l.OnLibraryCleanup(libraryevents.CleanupSkippedInUse, "delayed")
+	l.OnLibraryResolved("dd-lib-java-init", libraryevents.ResolutionCacheHit)
+	l.OnLibraryResolved("dd-lib-java-init", libraryevents.ResolutionDownloaded)
+	l.OnLibraryResolved("dd-lib-php-init", libraryevents.ResolutionFailed)
+	l.OnLibraryCleanup("dd-lib-java-init", libraryevents.CleanupSuccess, "immediate")
+	l.OnLibraryCleanup("dd-lib-php-init", libraryevents.CleanupSkippedInUse, "delayed")
 	l.OnLibraryDownload("dd-lib-java-init", "gcr.io", 250*time.Millisecond)
 
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(libraryevents.ResolutionCacheHit))))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(libraryevents.ResolutionDownloaded))))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(libraryevents.ResolutionFailed))))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(libraryevents.CleanupSuccess), "immediate")))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(libraryevents.CleanupSkippedInUse), "delayed")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues("dd-lib-java-init", string(libraryevents.ResolutionCacheHit))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues("dd-lib-java-init", string(libraryevents.ResolutionDownloaded))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues("dd-lib-php-init", string(libraryevents.ResolutionFailed))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues("dd-lib-java-init", string(libraryevents.CleanupSuccess), "immediate")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues("dd-lib-php-init", string(libraryevents.CleanupSkippedInUse), "delayed")))
 
 	// The download histogram is still populated; we just check the sample count
 	// exists for the right labels (bucket layout is tested elsewhere).
@@ -69,8 +69,8 @@ func TestLibraryListenerOnSnapshotSeedsGauges(t *testing.T) {
 
 	l := NewLibraryListener()
 	l.OnSnapshot(libraryevents.Snapshot{
-		CachedCountByPackage: map[string]int{"dd-lib-java-init": 2, "dd-lib-php-init": 1},
-		CachedBytesByPackage: map[string]int64{"dd-lib-java-init": 4096, "dd-lib-php-init": 64},
+		CachedCountByLibrary: map[string]int{"dd-lib-java-init": 2, "dd-lib-php-init": 1},
+		CachedBytesByLibrary: map[string]int64{"dd-lib-java-init": 4096, "dd-lib-php-init": 64},
 	})
 
 	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -73,6 +73,7 @@ var nodeVolumeUnmountAttempts = newCounterVec(
 var libraryResolutions = newCounterVec(
 	"library_resolutions_total",
 	"Counts the outcome of attempts to resolve a library for a volume",
+	"library",
 	"result",
 )
 
@@ -87,6 +88,7 @@ var libraryDownloadDuration = newHistogramVec(
 var libraryCleanup = newCounterVec(
 	"library_cleanup_total",
 	"Counts cleanup attempts for unused libraries",
+	"library",
 	"status",
 	"strategy",
 )
@@ -124,8 +126,10 @@ func RecordVolumeUnMountAttempt(status Status) {
 }
 
 // RecordLibraryResolution records the outcome of an attempt to resolve a library for a volume.
-func RecordLibraryResolution(result libraryevents.ResolutionResult) {
-	libraryResolutions.WithLabelValues(string(result)).Inc()
+// The library label is the package name (e.g. "dd-lib-java-init"); it may be empty
+// when the resolution failed before the library was identified.
+func RecordLibraryResolution(library string, result libraryevents.ResolutionResult) {
+	libraryResolutions.WithLabelValues(library, string(result)).Inc()
 }
 
 // ObserveLibraryDownloadDuration records the duration of a successful library download.
@@ -135,18 +139,20 @@ func ObserveLibraryDownloadDuration(library, registry string, d time.Duration) {
 }
 
 // RecordLibraryCleanup records the outcome of a cleanup attempt for an unused library.
-// The strategy label captures which cleanup policy was active (e.g. "immediate", "delayed").
-func RecordLibraryCleanup(status libraryevents.CleanupStatus, strategy string) {
-	libraryCleanup.WithLabelValues(string(status), strategy).Inc()
+// The library label is the package name (e.g. "dd-lib-java-init"); it may be empty
+// for legacy entries on disk that predate the metadata bucket. The strategy label
+// captures which cleanup policy was active (e.g. "immediate", "delayed").
+func RecordLibraryCleanup(library string, status libraryevents.CleanupStatus, strategy string) {
+	libraryCleanup.WithLabelValues(library, string(status), strategy).Inc()
 }
 
-// SetLibrariesCachedForPackage sets the number of cached library versions for a package.
-func SetLibrariesCachedForPackage(library string, count int) {
+// SetLibrariesCachedForLibrary sets the number of cached versions for a library.
+func SetLibrariesCachedForLibrary(library string, count int) {
 	librariesCached.WithLabelValues(library).Set(float64(count))
 }
 
-// SetLibrariesCachedBytesForPackage sets the cumulative on-disk size of cached libraries
-// for a given package, in bytes.
-func SetLibrariesCachedBytesForPackage(library string, bytes int64) {
+// SetLibrariesCachedBytesForLibrary sets the cumulative on-disk size of cached versions
+// for a given library, in bytes.
+func SetLibrariesCachedBytesForLibrary(library string, bytes int64) {
 	librariesCachedBytes.WithLabelValues(library).Set(float64(bytes))
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,6 +49,13 @@ func newHistogramVec(name, help string, buckets []float64, labels ...string) *pr
 	}, labels)
 }
 
+func newGaugeVec(name, help string, labels ...string) *prometheus.GaugeVec {
+	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: subsystem + separator + name,
+		Help: help,
+	}, labels)
+}
+
 var nodeVolumeMountAttempts = newCounterVec(
 	"node_publish_volume_attempts",
 	"Counts the number of publish volume requests received by the csi node server",
@@ -84,12 +91,26 @@ var libraryCleanup = newCounterVec(
 	"strategy",
 )
 
+var librariesCached = newGaugeVec(
+	"libraries_cached",
+	"Number of library versions currently stored on disk, per package",
+	"library",
+)
+
+var librariesCachedBytes = newGaugeVec(
+	"libraries_cached_bytes",
+	"Cumulative on-disk size of cached libraries, in bytes, per package",
+	"library",
+)
+
 func init() {
 	prometheus.MustRegister(nodeVolumeMountAttempts)
 	prometheus.MustRegister(nodeVolumeUnmountAttempts)
 	prometheus.MustRegister(libraryResolutions)
 	prometheus.MustRegister(libraryDownloadDuration)
 	prometheus.MustRegister(libraryCleanup)
+	prometheus.MustRegister(librariesCached)
+	prometheus.MustRegister(librariesCachedBytes)
 }
 
 // RecordVolumeMountAttempt records a volume mount attempt
@@ -117,4 +138,15 @@ func ObserveLibraryDownloadDuration(library, registry string, d time.Duration) {
 // The strategy label captures which cleanup policy was active (e.g. "immediate", "delayed").
 func RecordLibraryCleanup(status libraryevents.CleanupStatus, strategy string) {
 	libraryCleanup.WithLabelValues(string(status), strategy).Inc()
+}
+
+// SetLibrariesCachedForPackage sets the number of cached library versions for a package.
+func SetLibrariesCachedForPackage(library string, count int) {
+	librariesCached.WithLabelValues(library).Set(float64(count))
+}
+
+// SetLibrariesCachedBytesForPackage sets the cumulative on-disk size of cached libraries
+// for a given package, in bytes.
+func SetLibrariesCachedBytesForPackage(library string, bytes int64) {
+	librariesCachedBytes.WithLabelValues(library).Set(float64(bytes))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -19,27 +19,31 @@ import (
 func TestRecordLibraryResolution(t *testing.T) {
 	libraryResolutions.Reset()
 
-	RecordLibraryResolution(libraryevents.ResolutionCacheHit)
-	RecordLibraryResolution(libraryevents.ResolutionCacheHit)
-	RecordLibraryResolution(libraryevents.ResolutionDownloaded)
-	RecordLibraryResolution(libraryevents.ResolutionFailed)
+	RecordLibraryResolution("dd-lib-java-init", libraryevents.ResolutionCacheHit)
+	RecordLibraryResolution("dd-lib-java-init", libraryevents.ResolutionCacheHit)
+	RecordLibraryResolution("dd-lib-java-init", libraryevents.ResolutionDownloaded)
+	RecordLibraryResolution("dd-lib-php-init", libraryevents.ResolutionFailed)
+	RecordLibraryResolution("", libraryevents.ResolutionFailed)
 
-	require.Equal(t, float64(2), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(libraryevents.ResolutionCacheHit))))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(libraryevents.ResolutionDownloaded))))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues(string(libraryevents.ResolutionFailed))))
+	require.Equal(t, float64(2), testutil.ToFloat64(libraryResolutions.WithLabelValues("dd-lib-java-init", string(libraryevents.ResolutionCacheHit))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues("dd-lib-java-init", string(libraryevents.ResolutionDownloaded))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues("dd-lib-php-init", string(libraryevents.ResolutionFailed))))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryResolutions.WithLabelValues("", string(libraryevents.ResolutionFailed))))
 }
 
 func TestRecordLibraryCleanup(t *testing.T) {
 	libraryCleanup.Reset()
 
-	RecordLibraryCleanup(libraryevents.CleanupSuccess, "immediate")
-	RecordLibraryCleanup(libraryevents.CleanupSuccess, "immediate")
-	RecordLibraryCleanup(libraryevents.CleanupFailed, "immediate")
-	RecordLibraryCleanup(libraryevents.CleanupSkippedInUse, "delayed")
+	RecordLibraryCleanup("dd-lib-java-init", libraryevents.CleanupSuccess, "immediate")
+	RecordLibraryCleanup("dd-lib-java-init", libraryevents.CleanupSuccess, "immediate")
+	RecordLibraryCleanup("dd-lib-java-init", libraryevents.CleanupFailed, "immediate")
+	RecordLibraryCleanup("dd-lib-php-init", libraryevents.CleanupSkippedInUse, "delayed")
+	RecordLibraryCleanup("", libraryevents.CleanupFailed, "immediate")
 
-	require.Equal(t, float64(2), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(libraryevents.CleanupSuccess), "immediate")))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(libraryevents.CleanupFailed), "immediate")))
-	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues(string(libraryevents.CleanupSkippedInUse), "delayed")))
+	require.Equal(t, float64(2), testutil.ToFloat64(libraryCleanup.WithLabelValues("dd-lib-java-init", string(libraryevents.CleanupSuccess), "immediate")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues("dd-lib-java-init", string(libraryevents.CleanupFailed), "immediate")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues("dd-lib-php-init", string(libraryevents.CleanupSkippedInUse), "delayed")))
+	require.Equal(t, float64(1), testutil.ToFloat64(libraryCleanup.WithLabelValues("", string(libraryevents.CleanupFailed), "immediate")))
 }
 
 func TestObserveLibraryDownloadDuration(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Second slice of the library-lifecycle observability work (2/3). Adds two per-package gauges:

- `datadog_csi_driver_libraries_cached{library}` — number of library versions currently stored on disk.
- `datadog_csi_driver_libraries_cached_bytes{library}` — cumulative on-disk size, in bytes, of cached libraries.

Series that drop to zero are kept (`Set(0)`) so dashboards can observe the "nothing cached" state rather than seeing the series disappear.

To support these stateful gauges, the PR also introduces:

- A new **`library-metadata` bbolt bucket** that stores the package name and on-disk size for each cached library. Required to publish per-package gauges across driver restarts since the package name is otherwise only known at download time.
- In-memory aggregates inside `Database`, seeded once from the persisted state at `NewDatabase` and kept in sync with each `bbolt.Tx.Commit()`. Per-package counters are then served in O(1).
- Three new methods on `librarymanager.EventListener`: `OnLibraryCached`, `OnLibraryEvicted` and `OnSnapshot` (the last one is called at startup so dashboards reflect reality immediately without waiting for the first lifecycle event).

Stacked on top of #88 (1/3) which introduced the listener interface. The third PR will add `library_volume_links` on top of this.

### Motivation

Extracted from #86 to make the series reviewable.

The goal of the full series is to ship the six metrics defined by the [SSI observability RFC](https://docs.google.com/document/d/1S-xF7W5bXnDdpc8Djvy2y8OKaf1etbCgPCk5GxTeFrw). This PR covers two of the three remaining (gauge) metrics, both answering "how much disk does the SSI cache occupy, and how many distinct versions are kept?".

### Additional Notes

- `Downloader.Download` and `ArchiveExtractor.Extract` now return `(int64, error)`, where the `int64` is the cumulative size of regular files written. This lets the manager record the on-disk footprint without re-walking the store directory.
- **Migration**: libraries cached on disk before this release have no metadata recorded; they are not counted in the new gauges until they are downloaded again. The bias is expected to be short-lived because the library publisher is not yet in heavy use.

### Describe your test plan

- `pkg/librarymanager/db_test.go` covers `AddLibrary` / `RemoveLibrary` / `PackageCacheStats` / `Snapshot`, including: multi-version aggregation under the same package, `AddLibrary` idempotency (no double-counting on repeat), removal of the package entry when the last version is evicted, and blank-input validation across the public surface.
- `TestDatabaseMetadataPersistsAcrossRestart` reopens the database in a fresh process and asserts the aggregates are rebuilt from disk.
- `pkg/metrics/library_listener_test.go` asserts `OnLibraryCached` / `OnLibraryEvicted` move the gauges and that `OnSnapshot` wipes stale series before reseeding.
- Existing manager tests still pass after the listener call sites were added.