### PR TITLE
[3/3] Add library lifecycle metrics: library_volume_links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `datadog_csi_driver_library_cleanup_total{library,status,strategy}` (counter): cleanup attempts for unused libraries (`success`, `failed`, `skipped_in_use`).
   - `datadog_csi_driver_libraries_cached{library}` (gauge): number of versions currently stored on disk for each library.
   - `datadog_csi_driver_libraries_cached_bytes{library}` (gauge): cumulative on-disk size, in bytes, of cached versions for each library.
-- New `library-metadata` bucket in the on-disk bbolt database, storing the package name and on-disk size for each cached library. Required to publish per-package gauges across restarts.
+  - `datadog_csi_driver_library_volume_links{library}` (gauge): number of volumes currently linked to any cached version of a library.
+- New `library-metadata` bucket in the on-disk bbolt database, storing the package name and on-disk size for each cached library. Required to publish per-library gauges across restarts.
 
 ### Changed
 
 - `librarymanager` no longer depends on `pkg/metrics`. Lifecycle events are reported through a new `libraryevents.Listener` interface defined in a dedicated, dependency-free `pkg/libraryevents` package; the metrics-publishing implementation lives in `pkg/metrics` and is wired in `pkg/driver`.
+- `LinkVolume` now happens after the library has been confirmed on disk (cache hit) or recorded in the metadata bucket (successful download). This prevents dangling links if the download fails, and gives `library_volume_links` a stable library label.
+- `RemoveVolume` is now a no-op when the volume was never linked.
 
 ### Notes
 
-- Libraries cached on disk before this release have no metadata recorded; they are not counted in the `libraries_cached*` gauges until they are downloaded again. The bias is expected to be short-lived because the library publisher is not yet in heavy use.
+- Libraries cached on disk before this release have no metadata recorded; they are not counted in the `libraries_cached*` or `library_volume_links` gauges until they are downloaded again. The bias is expected to be short-lived because the library publisher is not yet in heavy use.
 
 ## [1.2.2] - 2026-04-21
 

--- a/pkg/libraryevents/libraryevents.go
+++ b/pkg/libraryevents/libraryevents.go
@@ -47,6 +47,9 @@ type Snapshot struct {
 	// CachedBytesByLibrary maps each library to the cumulative on-disk
 	// size, in bytes, of the cached versions for that library.
 	CachedBytesByLibrary map[string]int64
+	// VolumeLinksByLibrary maps each library to the number of volumes
+	// currently linked to any of its cached versions.
+	VolumeLinksByLibrary map[string]int
 }
 
 // Listener is notified by the library manager of significant lifecycle
@@ -89,6 +92,16 @@ type Listener interface {
 	// for a Gauge.Set.
 	OnLibraryEvicted(library string, cachedCount int, cachedBytes int64)
 
+	// OnVolumeLinked is called once a volume has been linked to a cached
+	// library version. volumeLinks is the per-library aggregate after
+	// the link, suitable for a Gauge.Set.
+	OnVolumeLinked(library string, volumeLinks int)
+
+	// OnVolumeUnlinked is called once a volume has been unlinked from a
+	// cached library version. volumeLinks is the per-library aggregate
+	// after the unlink (zero when the last volume is gone).
+	OnVolumeUnlinked(library string, volumeLinks int)
+
 	// OnSnapshot is called once at LibraryManager construction so the
 	// listener can seed its gauges with the persisted state and avoid the
 	// cold-start gap until the next event.
@@ -104,4 +117,6 @@ func (NoopListener) OnLibraryDownload(string, string, time.Duration) {}
 func (NoopListener) OnLibraryCleanup(string, CleanupStatus, string)  {}
 func (NoopListener) OnLibraryCached(string, int, int64)              {}
 func (NoopListener) OnLibraryEvicted(string, int, int64)             {}
+func (NoopListener) OnVolumeLinked(string, int)                      {}
+func (NoopListener) OnVolumeUnlinked(string, int)                    {}
 func (NoopListener) OnSnapshot(Snapshot)                             {}

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -78,6 +78,10 @@ type Database struct {
 	// cachedBytesByPackage sums the on-disk size of cached libraries per
 	// package name.
 	cachedBytesByPackage map[string]int64
+	// volumeLinksByPackage counts the number of volumes currently linked
+	// to any library of a given package. Updated atomically with the
+	// LinkVolume/UnlinkVolume bbolt transactions.
+	volumeLinksByPackage map[string]int
 }
 
 // NewDatabase initializes a new database. If a database file exists, it will re-use the existing file. Call close when
@@ -112,6 +116,7 @@ func NewDatabase(basePath string) (*Database, error) {
 		bbolt:                    db,
 		cachedLibrariesByPackage: map[string]int{},
 		cachedBytesByPackage:     map[string]int64{},
+		volumeLinksByPackage:     map[string]int{},
 	}
 
 	// Seed the in-memory aggregates from the on-disk metadata so the
@@ -124,22 +129,51 @@ func NewDatabase(basePath string) (*Database, error) {
 	return database, nil
 }
 
-// loadCaches scans LibraryMetadataBucket once at startup and rebuilds the
-// in-memory aggregates.
+// loadCaches scans LibraryMetadataBucket and LibraryMappingBucket once at
+// startup and rebuilds the in-memory aggregates. The two buckets are walked
+// in the same read transaction to guarantee a consistent snapshot.
 func (db *Database) loadCaches() error {
 	return db.bbolt.View(func(tx *bbolt.Tx) error {
-		bkt := tx.Bucket([]byte(LibraryMetadataBucket))
-		if bkt == nil {
+		metaBkt := tx.Bucket([]byte(LibraryMetadataBucket))
+		mappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
+
+		// libraryToPackage lets us project the per-library volume count
+		// from LibraryMappingBucket onto a per-package count via
+		// LibraryMetadataBucket.
+		libraryToPackage := map[string]string{}
+		if metaBkt != nil {
+			if err := metaBkt.ForEach(func(k, v []byte) error {
+				var meta libraryMetadata
+				if err := json.Unmarshal(v, &meta); err != nil {
+					return fmt.Errorf("could not unmarshal library metadata: %w", err)
+				}
+				db.cachedLibrariesByPackage[meta.Package]++
+				db.cachedBytesByPackage[meta.Package] += meta.SizeBytes
+				libraryToPackage[string(k)] = meta.Package
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+
+		if mappingBkt == nil {
 			return nil
 		}
-		return bkt.ForEach(func(_, v []byte) error {
-			var meta libraryMetadata
-			if err := json.Unmarshal(v, &meta); err != nil {
-				return fmt.Errorf("could not unmarshal library metadata: %w", err)
+		return mappingBkt.ForEachBucket(func(libraryKey []byte) error {
+			pkg, ok := libraryToPackage[string(libraryKey)]
+			if !ok {
+				// Library is on disk but predates the metadata bucket;
+				// we skip it (no package label available).
+				return nil
 			}
-			db.cachedLibrariesByPackage[meta.Package]++
-			db.cachedBytesByPackage[meta.Package] += meta.SizeBytes
-			return nil
+			libraryBkt := mappingBkt.Bucket(libraryKey)
+			if libraryBkt == nil {
+				return nil
+			}
+			return libraryBkt.ForEach(func(_, _ []byte) error {
+				db.volumeLinksByPackage[pkg]++
+				return nil
+			})
 		})
 	})
 }
@@ -272,6 +306,14 @@ func (db *Database) PackageCacheStats(packageName string) (int, int64) {
 	return db.cachedLibrariesByPackage[packageName], db.cachedBytesByPackage[packageName]
 }
 
+// VolumeLinkCount returns the number of volumes currently linked to any
+// library of the given package.
+func (db *Database) VolumeLinkCount(packageName string) int {
+	db.cacheMu.Lock()
+	defer db.cacheMu.Unlock()
+	return db.volumeLinksByPackage[packageName]
+}
+
 // PackageForLibrary returns the package name recorded for a library, or an
 // empty string when the library has no metadata (for instance because it
 // was added by an older driver version that did not yet persist
@@ -315,13 +357,21 @@ func (db *Database) Snapshot() libraryevents.Snapshot {
 	for pkg, n := range db.cachedBytesByPackage {
 		cachedBytes[pkg] = n
 	}
+	volumeLinks := make(map[string]int, len(db.volumeLinksByPackage))
+	for pkg, n := range db.volumeLinksByPackage {
+		volumeLinks[pkg] = n
+	}
 	return libraryevents.Snapshot{
 		CachedCountByLibrary: cachedCount,
 		CachedBytesByLibrary: cachedBytes,
+		VolumeLinksByLibrary: volumeLinks,
 	}
 }
 
 // LinkVolume creates a bidrectional mapping between the library and volume.
+// When per-library metadata is recorded (i.e. AddLibrary has been called
+// before LinkVolume), the per-package volume-links aggregate is updated
+// atomically with the bbolt transaction.
 func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 	// Validate input.
 	if libraryID == "" {
@@ -356,6 +406,12 @@ func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 		return fmt.Errorf("could not create bucket for library %s: %w", libraryID, err)
 	}
 
+	// If the volume is already linked there is nothing to do; skip the
+	// extra writes and the aggregate update.
+	if libraryBkt.Get([]byte(volumeID)) != nil {
+		return nil
+	}
+
 	// Create the bucket for the volume if it does not exist.
 	volumeBkt, err := volumeMappingBkt.CreateBucketIfNotExists([]byte(volumeID))
 	if err != nil {
@@ -388,23 +444,63 @@ func (db *Database) LinkVolume(libraryID string, volumeID string) error {
 		return fmt.Errorf("could not assign volume with id %s: %w", volumeID, err)
 	}
 
-	// Commit the transaction.
-	err = tx.Commit()
+	// Look up the package name now, while the transaction is still open
+	// and we have a consistent view. The lookup falls back to an empty
+	// string for libraries that predate the metadata bucket.
+	packageName, err := packageForLibraryInTx(tx, libraryID)
 	if err != nil {
+		return err
+	}
+
+	// Take cacheMu just long enough to update the aggregate and commit so
+	// readers never observe a state where bbolt and the in-memory cache
+	// disagree.
+	db.cacheMu.Lock()
+	if packageName != "" {
+		db.volumeLinksByPackage[packageName]++
+	}
+	if err := tx.Commit(); err != nil {
+		if packageName != "" {
+			db.volumeLinksByPackage[packageName]--
+		}
+		db.cacheMu.Unlock()
 		return fmt.Errorf("could not commit transaction: %w", err)
 	}
+	db.cacheMu.Unlock()
 
 	return nil
 }
 
+// packageForLibraryInTx is the transaction-bound flavour of PackageForLibrary
+// used internally by LinkVolume/UnlinkVolume to keep the aggregate update
+// consistent with the bbolt write.
+func packageForLibraryInTx(tx *bbolt.Tx, libraryID string) (string, error) {
+	bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+	if bkt == nil {
+		return "", nil
+	}
+	raw := bkt.Get([]byte(libraryID))
+	if raw == nil {
+		return "", nil
+	}
+	var meta libraryMetadata
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return "", fmt.Errorf("could not unmarshal library metadata: %w", err)
+	}
+	return meta.Package, nil
+}
+
 // UnlinkVolume removes the link for a given volume.
+// When the link existed and per-library metadata is recorded, the
+// per-package volume-links aggregate is decremented atomically with the
+// bbolt transaction.
 func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 	// Validate input.
 	if libraryID == "" {
 		return fmt.Errorf("library ID cannot be blank")
 	}
 	if volumeID == "" {
-		return fmt.Errorf(" volume ID cannot be blank")
+		return fmt.Errorf("volume ID cannot be blank")
 	}
 
 	// Start a transaction.
@@ -424,6 +520,13 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 	volumeMappingBkt := tx.Bucket([]byte(VolumeMappingBucket))
 	if volumeMappingBkt == nil {
 		return fmt.Errorf("library mapping bucket does not exist")
+	}
+
+	// Detect whether the link actually existed so the aggregate is only
+	// decremented for a real removal.
+	wasLinked := false
+	if libraryBucket := libraryMappingBkt.Bucket([]byte(libraryID)); libraryBucket != nil {
+		wasLinked = libraryBucket.Get([]byte(volumeID)) != nil
 	}
 
 	// Check if the library bucket exists.
@@ -466,11 +569,31 @@ func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
 		}
 	}
 
-	// Commit the transaction.
-	err = tx.Commit()
-	if err != nil {
+	// Look up the package while the transaction is still open so the
+	// aggregate update is consistent with the bbolt write.
+	packageName := ""
+	if wasLinked {
+		packageName, err = packageForLibraryInTx(tx, libraryID)
+		if err != nil {
+			return err
+		}
+	}
+
+	db.cacheMu.Lock()
+	if packageName != "" {
+		db.volumeLinksByPackage[packageName]--
+		if db.volumeLinksByPackage[packageName] <= 0 {
+			delete(db.volumeLinksByPackage, packageName)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		if packageName != "" {
+			db.volumeLinksByPackage[packageName]++
+		}
+		db.cacheMu.Unlock()
 		return fmt.Errorf("could not commit transaction: %w", err)
 	}
+	db.cacheMu.Unlock()
 
 	return nil
 }

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -183,3 +183,58 @@ func TestDatabaseValidatesBlankInputsForMetadata(t *testing.T) {
 	_, err = db.PackageForLibrary("")
 	require.Error(t, err)
 }
+
+func TestDatabaseVolumeLinksAggregateByPackage(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Aggregate is zero before any link is created.
+	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+
+	// Without metadata the aggregate is not touched even after a link.
+	require.NoError(t, db.LinkVolume("lib-id-1", "vol-1"))
+	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+
+	// Once metadata is recorded, subsequent links update the aggregate.
+	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 100))
+	require.NoError(t, db.AddLibrary("lib-id-2", "dd-lib-java-init", 200))
+	require.NoError(t, db.LinkVolume("lib-id-1", "vol-2"))
+	require.NoError(t, db.LinkVolume("lib-id-2", "vol-3"))
+	require.Equal(t, 2, db.VolumeLinkCount("dd-lib-java-init"))
+
+	// Re-linking the same volume is a no-op for the aggregate.
+	require.NoError(t, db.LinkVolume("lib-id-1", "vol-2"))
+	require.Equal(t, 2, db.VolumeLinkCount("dd-lib-java-init"))
+
+	// Unlinks decrement and eventually drop the package entry.
+	require.NoError(t, db.UnlinkVolume("lib-id-1", "vol-2"))
+	require.NoError(t, db.UnlinkVolume("lib-id-2", "vol-3"))
+	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+
+	// Unlinking an unknown volume is a no-op for the aggregate.
+	require.NoError(t, db.UnlinkVolume("lib-id-1", "never-existed"))
+	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+}
+
+func TestDatabaseVolumeLinksReloadedFromDisk(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 100))
+	require.NoError(t, db.LinkVolume("lib-id-1", "vol-1"))
+	require.NoError(t, db.LinkVolume("lib-id-1", "vol-2"))
+	require.NoError(t, db.Close())
+
+	db2, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db2.Close()
+
+	snap := db2.Snapshot()
+	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
+}

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -195,15 +195,11 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return "", fmt.Errorf("could not determine library ID: %w", err)
 	}
 
-	// Lock the package.
+	// Lock the package. The locker prevents cleanup from running while
+	// we resolve, so we can defer LinkVolume to after we have confirmed
+	// the library is on disk and recorded in the metadata bucket.
 	lm.locker.Lock(libraryID)
 	defer lm.locker.Unlock(libraryID)
-
-	// Link the library as a first step to ensure any cleanup processes know we need this library.
-	err = lm.db.LinkVolume(libraryID, volumeID)
-	if err != nil {
-		return "", err
-	}
 
 	// If the library already exists, return it.
 	path, err := lm.store.Get(libraryID)
@@ -212,6 +208,9 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	}
 	if path != "" {
 		log.Info("Library already cached", "image", lib.Image(), "path", path)
+		if err := lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
+			return "", err
+		}
 		result = libraryevents.ResolutionCacheHit
 		return path, nil
 	}
@@ -241,25 +240,55 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 
 	// Record the library in the metadata bucket and notify the listener.
 	// AddLibrary is the canonical writer for the per-library metadata; it
-	// must be called before any consumer relies on the package name being
-	// available for the given library ID.
+	// must be called before LinkVolume so the volume-links aggregate has
+	// the right package name to associate the link with.
 	if err := lm.db.AddLibrary(libraryID, lib.Name(), sizeBytes); err != nil {
 		return "", fmt.Errorf("could not record library metadata: %w", err)
 	}
 	count, totalBytes := lm.db.PackageCacheStats(lib.Name())
 	lm.listener.OnLibraryCached(lib.Name(), count, totalBytes)
 
+	if err := lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
+		return "", err
+	}
+
 	result = libraryevents.ResolutionDownloaded
 	return storePath, nil
 }
 
+// linkVolume persists the library/volume link and notifies the listener
+// with the resulting per-library count. It is intentionally a tiny helper:
+// keeping the listener invocation paired with the LinkVolume call avoids
+// the easy mistake of forgetting one of the two.
+func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string) error {
+	if err := lm.db.LinkVolume(libraryID, volumeID); err != nil {
+		return err
+	}
+	lm.listener.OnVolumeLinked(library, lm.db.VolumeLinkCount(library))
+	return nil
+}
+
 // RemoveVolume removes the link between the LibraryID and the VolumeID in the database.
 // If there are no more uses of the library, it is also removed from disk.
+// Calling RemoveVolume for a volume that was never linked is a no-op.
 func (lm *LibraryManager) RemoveVolume(ctx context.Context, volumeID string) error {
 	// Look up the linked library.
 	libraryID, err := lm.db.GetLibraryForVolume(volumeID)
 	if err != nil {
 		return fmt.Errorf("could not determine which library was linked for volume %s: %w", volumeID, err)
+	}
+	if libraryID == "" {
+		// Nothing to do: the volume was never linked or has already been
+		// removed. We return nil here to keep idempotency.
+		return nil
+	}
+
+	// Resolve the library name now, before the link (and possibly the
+	// metadata) is wiped, so we can notify the listener with the right
+	// gauge label.
+	library, err := lm.db.PackageForLibrary(libraryID)
+	if err != nil {
+		return fmt.Errorf("could not resolve library for ID %s: %w", libraryID, err)
 	}
 
 	// Unlink the volume from the database.
@@ -269,6 +298,9 @@ func (lm *LibraryManager) RemoveVolume(ctx context.Context, volumeID string) err
 	err = lm.db.UnlinkVolume(libraryID, volumeID)
 	if err != nil {
 		return fmt.Errorf("could not unlink volume ID %s: %w", volumeID, err)
+	}
+	if library != "" {
+		lm.listener.OnVolumeUnlinked(library, lm.db.VolumeLinkCount(library))
 	}
 
 	// Schedule cleanup - tryCleanupLibrary will check if the library is still in use

--- a/pkg/metrics/library_listener.go
+++ b/pkg/metrics/library_listener.go
@@ -59,16 +59,32 @@ func (*LibraryListener) OnLibraryEvicted(library string, cachedCount int, cached
 	SetLibrariesCachedBytesForLibrary(library, cachedBytes)
 }
 
+// OnVolumeLinked updates the per-library volume-links gauge.
+func (*LibraryListener) OnVolumeLinked(library string, volumeLinks int) {
+	SetLibraryVolumeLinksForLibrary(library, volumeLinks)
+}
+
+// OnVolumeUnlinked updates the per-library volume-links gauge. When the
+// last link for a library is removed the gauge is set to 0 rather than
+// deleted, so dashboards can distinguish "no volume" from "missing series".
+func (*LibraryListener) OnVolumeUnlinked(library string, volumeLinks int) {
+	SetLibraryVolumeLinksForLibrary(library, volumeLinks)
+}
+
 // OnSnapshot seeds the per-library gauges from the persisted state. Reset
 // is used so libraries that disappeared between two driver runs are not
 // stuck reporting stale values.
 func (*LibraryListener) OnSnapshot(s libraryevents.Snapshot) {
 	librariesCached.Reset()
 	librariesCachedBytes.Reset()
+	libraryVolumeLinks.Reset()
 	for library, count := range s.CachedCountByLibrary {
 		SetLibrariesCachedForLibrary(library, count)
 	}
 	for library, bytes := range s.CachedBytesByLibrary {
 		SetLibrariesCachedBytesForLibrary(library, bytes)
+	}
+	for library, links := range s.VolumeLinksByLibrary {
+		SetLibraryVolumeLinksForLibrary(library, links)
 	}
 }

--- a/pkg/metrics/library_listener_test.go
+++ b/pkg/metrics/library_listener_test.go
@@ -60,23 +60,39 @@ func TestLibraryListenerCachedAndEvictedSetGauges(t *testing.T) {
 	require.Equal(t, float64(0), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
 }
 
+func TestLibraryListenerVolumeLinkedAndUnlinkedSetGauge(t *testing.T) {
+	libraryVolumeLinks.Reset()
+
+	l := NewLibraryListener()
+	l.OnVolumeLinked("dd-lib-java-init", 3)
+	require.Equal(t, float64(3), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+
+	l.OnVolumeUnlinked("dd-lib-java-init", 0)
+	require.Equal(t, float64(0), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
+}
+
 func TestLibraryListenerOnSnapshotSeedsGauges(t *testing.T) {
 	librariesCached.Reset()
 	librariesCachedBytes.Reset()
+	libraryVolumeLinks.Reset()
 
 	// Pre-existing stale series should be wiped by Reset inside OnSnapshot.
 	librariesCached.WithLabelValues("stale").Set(7)
+	libraryVolumeLinks.WithLabelValues("stale").Set(7)
 
 	l := NewLibraryListener()
 	l.OnSnapshot(libraryevents.Snapshot{
 		CachedCountByLibrary: map[string]int{"dd-lib-java-init": 2, "dd-lib-php-init": 1},
 		CachedBytesByLibrary: map[string]int64{"dd-lib-java-init": 4096, "dd-lib-php-init": 64},
+		VolumeLinksByLibrary: map[string]int{"dd-lib-java-init": 5},
 	})
 
 	require.Equal(t, float64(2), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-java-init")))
 	require.Equal(t, float64(4096), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-java-init")))
 	require.Equal(t, float64(1), testutil.ToFloat64(librariesCached.WithLabelValues("dd-lib-php-init")))
 	require.Equal(t, float64(64), testutil.ToFloat64(librariesCachedBytes.WithLabelValues("dd-lib-php-init")))
+	require.Equal(t, float64(5), testutil.ToFloat64(libraryVolumeLinks.WithLabelValues("dd-lib-java-init")))
 
 	require.Equal(t, 2, testutil.CollectAndCount(librariesCached), "stale series should be evicted")
+	require.Equal(t, 1, testutil.CollectAndCount(libraryVolumeLinks), "stale series should be evicted")
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -105,6 +105,12 @@ var librariesCachedBytes = newGaugeVec(
 	"library",
 )
 
+var libraryVolumeLinks = newGaugeVec(
+	"library_volume_links",
+	"Number of volumes currently linked to a library",
+	"library",
+)
+
 func init() {
 	prometheus.MustRegister(nodeVolumeMountAttempts)
 	prometheus.MustRegister(nodeVolumeUnmountAttempts)
@@ -113,6 +119,7 @@ func init() {
 	prometheus.MustRegister(libraryCleanup)
 	prometheus.MustRegister(librariesCached)
 	prometheus.MustRegister(librariesCachedBytes)
+	prometheus.MustRegister(libraryVolumeLinks)
 }
 
 // RecordVolumeMountAttempt records a volume mount attempt
@@ -155,4 +162,10 @@ func SetLibrariesCachedForLibrary(library string, count int) {
 // for a given library, in bytes.
 func SetLibrariesCachedBytesForLibrary(library string, bytes int64) {
 	librariesCachedBytes.WithLabelValues(library).Set(float64(bytes))
+}
+
+// SetLibraryVolumeLinksForLibrary sets the number of volumes currently linked
+// to any cached version of the given library.
+func SetLibraryVolumeLinksForLibrary(library string, links int) {
+	libraryVolumeLinks.WithLabelValues(library).Set(float64(links))
 }


### PR DESCRIPTION
### What does this PR do?

Final slice of the library-lifecycle observability work (3/3). Adds the last per-package gauge:

- `datadog_csi_driver_library_volume_links{library}` — number of volumes currently linked to a library, per package.

Series that drop to zero are kept (`Set(0)`) so dashboards can observe the "no volume linked" state rather than seeing the series disappear.

To support this stateful gauge, the PR adds:

- A new `volumeLinksByPackage` in-memory aggregate inside `Database`, updated atomically with each `LinkVolume` / `UnlinkVolume` bbolt transaction and seeded from disk at startup (`loadCaches` now walks both `library-metadata` and `library-mappings` in the same read transaction).
- Two new methods on `librarymanager.EventListener`: `OnVolumeLinked` and `OnVolumeUnlinked`. `OnSnapshot` is extended to also seed the new gauge.

Stacked on top of #89 (2/3) which introduced the `library-metadata` bucket the new aggregate relies on.

### Motivation

Extracted from #86 to make the series reviewable.

The goal of the full series is to ship the six metrics defined by the [SSI observability RFC](https://docs.google.com/document/d/1S-xF7W5bXnDdpc8Djvy2y8OKaf1etbCgPCk5GxTeFrw). This last PR answers "how many volumes are mounted per package right now?".

### Additional Notes

- `LinkVolume` is now deferred until after the library has been confirmed on disk (cache hit) or recorded in the metadata bucket (successful download). The per-library lock guards against concurrent cleanup, so the reorder is safe; it also removes the previous "dangling link on download failure" foot-gun and gives the new gauge a stable package name to label with.
- `RemoveVolume` is now a no-op for volumes that were never linked, which makes the entry point idempotent under retries (e.g. `NodeUnpublish` after a failed `NodePublish`).
- **Migration**: libraries cached on disk before this release have no metadata recorded; they are not counted in the new gauge until they are downloaded again.

### Describe your test plan

- `pkg/librarymanager/db_test.go` covers the aggregate behavior: no-op for libraries without metadata, idempotency on repeat `LinkVolume`, decrement-then-drop on `UnlinkVolume`, and no-op on `UnlinkVolume` for an unknown volume.
- `TestDatabaseVolumeLinksReloadedFromDisk` closes the database and reopens it to assert the aggregate is rebuilt from disk.
- `pkg/metrics/library_listener_test.go` asserts `OnVolumeLinked` / `OnVolumeUnlinked` move the gauge and that `OnSnapshot` wipes stale series before reseeding.
- Existing manager tests still pass with the reordered `LinkVolume` and the idempotent `RemoveVolume`.