### PR TITLE
Simplify library manager DB schema to flat buckets with ref counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `datadog_csi_driver_libraries_cached{library}` (gauge): number of versions currently stored on disk for each library.
   - `datadog_csi_driver_libraries_cached_bytes{library}` (gauge): cumulative on-disk size, in bytes, of cached versions for each library.
   - `datadog_csi_driver_library_volume_links{library}` (gauge): number of volumes currently linked to any cached version of a library.
-- New `library-metadata` bucket in the on-disk bbolt database, storing the package name and on-disk size for each cached library. Required to publish per-library gauges across restarts.
+- The on-disk bbolt database now stores, for each cached library, its package name, on-disk size and live volume reference count. Required to publish per-library gauges across restarts.
 
 ### Changed
 
 - `librarymanager` no longer depends on `pkg/metrics`. Lifecycle events are reported through a new `libraryevents.Listener` interface defined in a dedicated, dependency-free `pkg/libraryevents` package; the metrics-publishing implementation lives in `pkg/metrics` and is wired in `pkg/driver`.
-- `LinkVolume` now happens after the library has been confirmed on disk (cache hit) or recorded in the metadata bucket (successful download). This prevents dangling links if the download fails, and gives `library_volume_links` a stable library label.
+- `LinkVolume` now happens after the library has been confirmed on disk (cache hit) or recorded (successful download). This prevents dangling links if the download fails, and gives `library_volume_links` a stable library label.
 - `RemoveVolume` is now a no-op when the volume was never linked.
+- The on-disk bbolt schema was simplified to two flat buckets (`volumes`, `libraries`) replacing the previous nested `library-mappings`/`volume-mappings` buckets and the per-library metadata bucket. Existing databases are migrated in place on the first start after upgrade, preserving volume links and library metadata.
 
 ### Notes
 

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -362,7 +362,7 @@ func (db *Database) GetLibrary(libraryID string) (LibraryInfo, bool, error) {
 			return fmt.Errorf("could not unmarshal library record: %w", err)
 		}
 		found = true
-		info = LibraryInfo{Package: rec.Package, SizeBytes: rec.SizeBytes, VolumeCount: rec.VolumeCount}
+		info = LibraryInfo(rec)
 		return nil
 	})
 	return info, found, err

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -150,6 +150,20 @@ func migrate(tx *bbolt.Tx) error {
 				return nil
 			}
 			return libBkt.ForEach(func(volumeKey, _ []byte) error {
+				// The legacy LinkVolume only checked the per-library
+				// sub-bucket, so the same volume could be mapped under
+				// several libraries. Migrate each volume exactly once
+				// (first writer wins) so the flat record and the owning
+				// library's VolumeCount stay consistent. Counting every
+				// occurrence would leave the overwritten libraries with a
+				// positive count for a volume they no longer own, so they
+				// would never be cleaned up and their gauges would stay
+				// inflated.
+				if _, migrated, err := getVolume(volumesBkt, string(volumeKey)); err != nil {
+					return err
+				} else if migrated {
+					return nil
+				}
 				if err := putVolume(volumesBkt, string(volumeKey), volumeRecord{LibraryID: libraryID}); err != nil {
 					return err
 				}
@@ -226,8 +240,12 @@ func (db *Database) RemoveLibrary(libraryID string) error {
 }
 
 // LinkVolume records that volumeID uses libraryID and increments the
-// library's volume count. It is idempotent: linking an already-linked volume
-// is a no-op.
+// library's volume count. Re-linking a volume to the same library is an
+// idempotent no-op. Re-linking a volume that is already tracked under a
+// different library (for instance a volume re-published against a new
+// library/version without an intervening unlink) moves the link to the new
+// library and decrements the previous one, so a volume always maps to exactly
+// one library and the counts never drift.
 func (db *Database) LinkVolume(libraryID, volumeID string) error {
 	if libraryID == "" {
 		return fmt.Errorf("library ID cannot be blank")
@@ -243,12 +261,30 @@ func (db *Database) LinkVolume(libraryID, volumeID string) error {
 			return fmt.Errorf("database buckets do not exist")
 		}
 
-		// If the volume is already tracked there is nothing to do; skip the
-		// write and the count update to keep the operation idempotent.
-		if _, linked, err := getVolume(volumesBkt, volumeID); err != nil {
+		// Inspect any existing link for this volume. Re-linking to the same
+		// library is a no-op (keeps the operation idempotent). Re-linking to
+		// a different library means the volume was re-published against a new
+		// library without an intervening unlink: decrement the previous
+		// library before re-pointing the volume below, so the volume stays
+		// mapped to exactly one library and the counts never drift.
+		existing, linked, err := getVolume(volumesBkt, volumeID)
+		if err != nil {
 			return err
-		} else if linked {
-			return nil
+		}
+		if linked {
+			if existing.LibraryID == libraryID {
+				return nil
+			}
+			oldRec, err := getLibrary(librariesBkt, existing.LibraryID)
+			if err != nil {
+				return err
+			}
+			if oldRec.VolumeCount > 0 {
+				oldRec.VolumeCount--
+				if err := putLibrary(librariesBkt, existing.LibraryID, oldRec); err != nil {
+					return err
+				}
+			}
 		}
 
 		if err := putVolume(volumesBkt, volumeID, volumeRecord{LibraryID: libraryID}); err != nil {

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -251,60 +251,34 @@ func (db *Database) RemoveLibrary(libraryID string) error {
 // already-cached library or had to download it; it is persisted on the record
 // together with a creation timestamp.
 //
-// Re-linking a volume to the same library is an idempotent no-op. Re-linking a
-// volume that is already tracked under a different library moves the link to
-// the new library and decrements the previous one, so a volume always maps to
-// exactly one library and the counts never drift. This transfer happens when a
-// volume is re-published and resolves to a different library ID without an
-// intervening unlink — for instance a mutable tag (such as ":latest") whose
-// digest changed between a publish that failed after linking and the kubelet's
-// retry.
-//
-// It returns the ID of the library the volume was previously linked to when a
-// transfer happened (empty otherwise). Callers should treat a non-empty
-// previousLibraryID like an unlink and schedule cleanup for it, since the
-// transfer may have brought its volume count to zero.
-func (db *Database) LinkVolume(libraryID, volumeID string, fromCache bool) (previousLibraryID string, err error) {
+// A volume maps to exactly one library for its whole lifetime: callers resolve
+// an already-linked volume from its existing record instead of re-resolving the
+// image, so LinkVolume is only reached for volumes that are not yet linked.
+// Linking a volume that is already tracked is therefore treated as an
+// idempotent no-op rather than re-pointing it, which keeps the per-library
+// counts from drifting even if the function is called twice.
+func (db *Database) LinkVolume(libraryID, volumeID string, fromCache bool) error {
 	if libraryID == "" {
-		return "", fmt.Errorf("library ID cannot be blank")
+		return fmt.Errorf("library ID cannot be blank")
 	}
 	if volumeID == "" {
-		return "", fmt.Errorf("volume ID cannot be blank")
+		return fmt.Errorf("volume ID cannot be blank")
 	}
 
-	err = db.bbolt.Update(func(tx *bbolt.Tx) error {
+	return db.bbolt.Update(func(tx *bbolt.Tx) error {
 		volumesBkt := tx.Bucket([]byte(VolumesBucket))
 		librariesBkt := tx.Bucket([]byte(LibrariesBucket))
 		if volumesBkt == nil || librariesBkt == nil {
 			return fmt.Errorf("database buckets do not exist")
 		}
 
-		// Inspect any existing link for this volume. Re-linking to the same
-		// library is a no-op (keeps the operation idempotent). Re-linking to
-		// a different library means the volume resolved to a new library ID
-		// without an intervening unlink (e.g. a mutable tag whose digest
-		// changed across a failed publish and the following retry): decrement
-		// the previous library before re-pointing the volume below, so the
-		// volume stays mapped to exactly one library and the counts never drift.
-		existing, linked, err := getVolume(volumesBkt, volumeID)
-		if err != nil {
+		// A volume is only ever linked once (re-publishes reuse the existing
+		// record upstream). If a record already exists, stay idempotent and
+		// do not touch the counts.
+		if _, linked, err := getVolume(volumesBkt, volumeID); err != nil {
 			return err
-		}
-		if linked {
-			if existing.LibraryID == libraryID {
-				return nil
-			}
-			previousLibraryID = existing.LibraryID
-			oldRec, err := getLibrary(librariesBkt, existing.LibraryID)
-			if err != nil {
-				return err
-			}
-			if oldRec.VolumeCount > 0 {
-				oldRec.VolumeCount--
-				if err := putLibrary(librariesBkt, existing.LibraryID, oldRec); err != nil {
-					return err
-				}
-			}
+		} else if linked {
+			return nil
 		}
 
 		if err := putVolume(volumesBkt, volumeID, volumeRecord{
@@ -321,10 +295,6 @@ func (db *Database) LinkVolume(libraryID, volumeID string, fromCache bool) (prev
 		rec.VolumeCount++
 		return putLibrary(librariesBkt, libraryID, rec)
 	})
-	if err != nil {
-		return "", err
-	}
-	return previousLibraryID, nil
 }
 
 // UnlinkVolume removes the link for a volume and decrements the owning

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -403,41 +403,6 @@ func (db *Database) Snapshot() (libraryevents.Snapshot, error) {
 	return snap, nil
 }
 
-// PackageStats returns the per-package aggregates for a single package: the
-// number of cached versions, their cumulative on-disk size in bytes, and the
-// number of volumes linked to any of them. It scans LibrariesBucket, which is
-// cheap because a node only ever caches a handful of libraries. It is the
-// per-package counterpart of Snapshot, used to label the gauge events the
-// manager emits on each state change.
-func (db *Database) PackageStats(packageName string) (cachedCount int, cachedBytes int64, volumeLinks int, err error) {
-	if packageName == "" {
-		return 0, 0, 0, nil
-	}
-	err = db.bbolt.View(func(tx *bbolt.Tx) error {
-		bkt := tx.Bucket([]byte(LibrariesBucket))
-		if bkt == nil {
-			return nil
-		}
-		return bkt.ForEach(func(_, v []byte) error {
-			var rec libraryRecord
-			if err := json.Unmarshal(v, &rec); err != nil {
-				return fmt.Errorf("could not unmarshal library record: %w", err)
-			}
-			if rec.Package != packageName {
-				return nil
-			}
-			cachedCount++
-			cachedBytes += rec.SizeBytes
-			volumeLinks += rec.VolumeCount
-			return nil
-		})
-	})
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	return cachedCount, cachedBytes, volumeLinks, nil
-}
-
 // getLibrary reads and decodes a library record. A missing key yields a zero
 // record and no error so callers can treat it as an upsert base.
 func getLibrary(bkt *bbolt.Bucket, libraryID string) (libraryRecord, error) {

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -246,15 +246,20 @@ func (db *Database) RemoveLibrary(libraryID string) error {
 // library/version without an intervening unlink) moves the link to the new
 // library and decrements the previous one, so a volume always maps to exactly
 // one library and the counts never drift.
-func (db *Database) LinkVolume(libraryID, volumeID string) error {
+//
+// It returns the ID of the library the volume was previously linked to when a
+// transfer happened (empty otherwise). Callers should treat a non-empty
+// previousLibraryID like an unlink and schedule cleanup for it, since the
+// transfer may have brought its volume count to zero.
+func (db *Database) LinkVolume(libraryID, volumeID string) (previousLibraryID string, err error) {
 	if libraryID == "" {
-		return fmt.Errorf("library ID cannot be blank")
+		return "", fmt.Errorf("library ID cannot be blank")
 	}
 	if volumeID == "" {
-		return fmt.Errorf("volume ID cannot be blank")
+		return "", fmt.Errorf("volume ID cannot be blank")
 	}
 
-	return db.bbolt.Update(func(tx *bbolt.Tx) error {
+	err = db.bbolt.Update(func(tx *bbolt.Tx) error {
 		volumesBkt := tx.Bucket([]byte(VolumesBucket))
 		librariesBkt := tx.Bucket([]byte(LibrariesBucket))
 		if volumesBkt == nil || librariesBkt == nil {
@@ -275,6 +280,7 @@ func (db *Database) LinkVolume(libraryID, volumeID string) error {
 			if existing.LibraryID == libraryID {
 				return nil
 			}
+			previousLibraryID = existing.LibraryID
 			oldRec, err := getLibrary(librariesBkt, existing.LibraryID)
 			if err != nil {
 				return err
@@ -297,6 +303,10 @@ func (db *Database) LinkVolume(libraryID, volumeID string) error {
 		rec.VolumeCount++
 		return putLibrary(librariesBkt, libraryID, rec)
 	})
+	if err != nil {
+		return "", err
+	}
+	return previousLibraryID, nil
 }
 
 // UnlinkVolume removes the link for a volume and decrements the owning

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/libraryevents"
 	"go.etcd.io/bbolt"
@@ -41,6 +42,12 @@ const (
 type volumeRecord struct {
 	// LibraryID is the ID of the library the volume is mounted from.
 	LibraryID string `json:"library_id"`
+	// CreatedAt is when the link was recorded. Records migrated from the
+	// legacy schema have a zero value.
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	// FromCache reports whether the publish that created this link reused an
+	// already-cached library (true) or had to download it first (false).
+	FromCache bool `json:"from_cache,omitempty"`
 }
 
 // libraryRecord is the value stored in LibrariesBucket.
@@ -240,18 +247,24 @@ func (db *Database) RemoveLibrary(libraryID string) error {
 }
 
 // LinkVolume records that volumeID uses libraryID and increments the
-// library's volume count. Re-linking a volume to the same library is an
-// idempotent no-op. Re-linking a volume that is already tracked under a
-// different library (for instance a volume re-published against a new
-// library/version without an intervening unlink) moves the link to the new
-// library and decrements the previous one, so a volume always maps to exactly
-// one library and the counts never drift.
+// library's volume count. fromCache notes whether the publish reused an
+// already-cached library or had to download it; it is persisted on the record
+// together with a creation timestamp.
+//
+// Re-linking a volume to the same library is an idempotent no-op. Re-linking a
+// volume that is already tracked under a different library moves the link to
+// the new library and decrements the previous one, so a volume always maps to
+// exactly one library and the counts never drift. This transfer happens when a
+// volume is re-published and resolves to a different library ID without an
+// intervening unlink — for instance a mutable tag (such as ":latest") whose
+// digest changed between a publish that failed after linking and the kubelet's
+// retry.
 //
 // It returns the ID of the library the volume was previously linked to when a
 // transfer happened (empty otherwise). Callers should treat a non-empty
 // previousLibraryID like an unlink and schedule cleanup for it, since the
 // transfer may have brought its volume count to zero.
-func (db *Database) LinkVolume(libraryID, volumeID string) (previousLibraryID string, err error) {
+func (db *Database) LinkVolume(libraryID, volumeID string, fromCache bool) (previousLibraryID string, err error) {
 	if libraryID == "" {
 		return "", fmt.Errorf("library ID cannot be blank")
 	}
@@ -268,10 +281,11 @@ func (db *Database) LinkVolume(libraryID, volumeID string) (previousLibraryID st
 
 		// Inspect any existing link for this volume. Re-linking to the same
 		// library is a no-op (keeps the operation idempotent). Re-linking to
-		// a different library means the volume was re-published against a new
-		// library without an intervening unlink: decrement the previous
-		// library before re-pointing the volume below, so the volume stays
-		// mapped to exactly one library and the counts never drift.
+		// a different library means the volume resolved to a new library ID
+		// without an intervening unlink (e.g. a mutable tag whose digest
+		// changed across a failed publish and the following retry): decrement
+		// the previous library before re-pointing the volume below, so the
+		// volume stays mapped to exactly one library and the counts never drift.
 		existing, linked, err := getVolume(volumesBkt, volumeID)
 		if err != nil {
 			return err
@@ -293,7 +307,11 @@ func (db *Database) LinkVolume(libraryID, volumeID string) (previousLibraryID st
 			}
 		}
 
-		if err := putVolume(volumesBkt, volumeID, volumeRecord{LibraryID: libraryID}); err != nil {
+		if err := putVolume(volumesBkt, volumeID, volumeRecord{
+			LibraryID: libraryID,
+			CreatedAt: time.Now().UTC(),
+			FromCache: fromCache,
+		}); err != nil {
 			return err
 		}
 		rec, err := getLibrary(librariesBkt, libraryID)

--- a/pkg/librarymanager/db.go
+++ b/pkg/librarymanager/db.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"sync"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/libraryevents"
 	"go.etcd.io/bbolt"
@@ -18,73 +17,81 @@ import (
 const (
 	// DatabaseFileName is the name of the database file created by bbolt.
 	DatabaseFileName = "datadog-csi-driver.db"
-	// LibraryMappingBucket is the name of the bucket to map libraries. Conceptually, the key structure is as follows:
-	//     /library-mappings/{{ library_id }}/{{ volume_id }}
-	LibraryMappingBucket = "library-mappings"
-	// VolumeMappingBucket is the bucket to map volumes. Conceptually, the key structure is as follows:
-	//     /volume-mappings/{{ volume_id }}/{{ library_id }}
-	VolumeMappingBucket = "volume-mappings"
-	// LibraryMetadataBucket stores per-library metadata indexed by library_id.
-	// The value is a JSON-encoded libraryMetadata. The bucket is needed
-	// because the package name is otherwise only known at the moment a
-	// library is added to the cache, and is required to publish
-	// per-package gauges after a process restart.
-	LibraryMetadataBucket = "library-metadata"
+
+	// VolumesBucket maps a volume to the library it uses. Key = volume ID,
+	// value = JSON volumeRecord. The relationship is 1:1 (a volume mounts
+	// exactly one library), so a flat bucket is all that is needed.
+	VolumesBucket = "volumes"
+	// LibrariesBucket holds one record per cached library. Key = library ID
+	// (the image digest), value = JSON libraryRecord. It is the single
+	// source of truth for the package label, the on-disk size and the number
+	// of volumes currently using the library.
+	LibrariesBucket = "libraries"
+
+	// The following buckets belong to the legacy nested-bucket schema and are
+	// only referenced by migrate() to upgrade existing databases in place.
+	legacyLibraryMappingBucket  = "library-mappings"
+	legacyVolumeMappingBucket   = "volume-mappings"
+	legacyLibraryMetadataBucket = "library-metadata"
 )
 
-type linkedVolume struct{}
+// volumeRecord is the value stored in VolumesBucket. It is a struct (rather
+// than a bare library ID) so that fields can be added later without breaking
+// existing databases.
+type volumeRecord struct {
+	// LibraryID is the ID of the library the volume is mounted from.
+	LibraryID string `json:"library_id"`
+}
 
-type linkedLibrary struct{}
-
-// libraryMetadata is the value stored in LibraryMetadataBucket. The struct
-// is kept small on purpose: any field added here must be tolerant to being
-// missing on records produced by older driver versions.
-type libraryMetadata struct {
-	// Package is the canonical package name (e.g. "dd-lib-java-init") that
-	// shares its value across all versions of the same library and is used
-	// as the metric label.
+// libraryRecord is the value stored in LibrariesBucket.
+type libraryRecord struct {
+	// Package is the canonical package name (e.g. "dd-lib-java-init") shared
+	// by every version of the library and used as the metric label. It may
+	// be empty for libraries migrated from a database that predates the
+	// per-library metadata.
 	Package string `json:"package,omitempty"`
 	// SizeBytes is the on-disk size of the library, in bytes.
 	SizeBytes int64 `json:"size_bytes,omitempty"`
+	// VolumeCount is the number of volumes currently linked to this library.
+	// It replaces the per-library volume sub-bucket of the legacy schema.
+	VolumeCount int `json:"volume_count,omitempty"`
 }
 
-// Database is a wrapper around bbolt with business logic for the library manager.
+// LibraryInfo is the public, read-only view of a library record returned by
+// GetLibrary.
+type LibraryInfo struct {
+	// Package is the canonical package name used as the metric label. It is
+	// empty for legacy entries that predate per-library metadata.
+	Package string
+	// SizeBytes is the on-disk size of the library, in bytes.
+	SizeBytes int64
+	// VolumeCount is the number of volumes currently linked to the library.
+	VolumeCount int
+}
+
+// Database is a thin wrapper around bbolt.
 //
-// # Transaction Consistency Guarantees
+// # Transaction consistency
 //
-// bbolt provides serializable isolation, the highest level of transaction isolation:
-//   - Write transactions are mutually exclusive (only one can run at a time)
-//   - Read transactions see a consistent snapshot of the database at the time they started
-//   - All operations within a single transaction are atomic (all-or-nothing)
+// bbolt provides serializable isolation: write transactions are mutually
+// exclusive, reads see a consistent snapshot, and every transaction is
+// atomic. As a result each method here is a single self-contained
+// transaction and the database keeps no in-memory bookkeeping: the
+// per-package aggregates the metrics listener needs are derived on demand by
+// scanning LibrariesBucket (see Snapshot), which is cheap because a node only
+// ever caches a handful of libraries.
 //
-// The defer tx.Rollback() pattern is safe: if Commit() was already called, Rollback() is a no-op.
+// # External locking
 //
-// # External Locking Requirements
-//
-// While individual database transactions are atomic, operations that span multiple transactions
-// or combine database operations with filesystem operations (e.g., LinkVolume + store.Add)
-// require external synchronization. The LibraryManager uses a Locker to coordinate these
-// compound operations on a per-library basis.
+// Operations that combine a database write with a filesystem operation (e.g.
+// LinkVolume followed by store.Add) still require external synchronisation;
+// the LibraryManager uses a per-library Locker for that.
 type Database struct {
 	bbolt *bbolt.DB
-
-	// cacheMu guards the in-memory aggregates below. They are eventually
-	// consistent with the LibraryMetadataBucket: writers take the lock just
-	// before tx.Commit() so callers that only read aggregates never block
-	// long-running bbolt transactions.
-	cacheMu sync.Mutex
-	// cachedLibrariesByPackage counts cached library IDs per package name.
-	cachedLibrariesByPackage map[string]int
-	// cachedBytesByPackage sums the on-disk size of cached libraries per
-	// package name.
-	cachedBytesByPackage map[string]int64
-	// volumeLinksByPackage counts the number of volumes currently linked
-	// to any library of a given package. Updated atomically with the
-	// LinkVolume/UnlinkVolume bbolt transactions.
-	volumeLinksByPackage map[string]int
 }
 
-// NewDatabase initializes a new database. If a database file exists, it will re-use the existing file. Call close when
+// NewDatabase initializes a new database. If a database file exists it is
+// reused (and migrated from the legacy schema if necessary). Call Close when
 // you are done.
 func NewDatabase(basePath string) (*Database, error) {
 	path := filepath.Join(basePath, DatabaseFileName)
@@ -93,105 +100,92 @@ func NewDatabase(basePath string) (*Database, error) {
 		return nil, fmt.Errorf("could not open database at %s: %w", path, err)
 	}
 
-	err = db.Update(func(tx *bbolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists([]byte(LibraryMappingBucket))
-		if err != nil {
-			return fmt.Errorf("failed to create bucket %s: %w", LibraryMappingBucket, err)
-		}
-		_, err = tx.CreateBucketIfNotExists([]byte(VolumeMappingBucket))
-		if err != nil {
-			return fmt.Errorf("failed to create bucket %s: %w", VolumeMappingBucket, err)
-		}
-		_, err = tx.CreateBucketIfNotExists([]byte(LibraryMetadataBucket))
-		if err != nil {
-			return fmt.Errorf("failed to create bucket %s: %w", LibraryMetadataBucket, err)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("could not create initial buckets: %w", err)
-	}
-
-	database := &Database{
-		bbolt:                    db,
-		cachedLibrariesByPackage: map[string]int{},
-		cachedBytesByPackage:     map[string]int64{},
-		volumeLinksByPackage:     map[string]int{},
-	}
-
-	// Seed the in-memory aggregates from the on-disk metadata so the
-	// listener can publish accurate gauges immediately after startup.
-	if err := database.loadCaches(); err != nil {
+	if err := db.Update(migrate); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("could not load caches: %w", err)
+		return nil, fmt.Errorf("could not initialize database: %w", err)
 	}
 
-	return database, nil
+	return &Database{bbolt: db}, nil
 }
 
-// loadCaches scans LibraryMetadataBucket and LibraryMappingBucket once at
-// startup and rebuilds the in-memory aggregates. The two buckets are walked
-// in the same read transaction to guarantee a consistent snapshot.
-func (db *Database) loadCaches() error {
-	return db.bbolt.View(func(tx *bbolt.Tx) error {
-		metaBkt := tx.Bucket([]byte(LibraryMetadataBucket))
-		mappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
+// migrate ensures the current buckets exist and, on the first run after an
+// upgrade, rewrites the legacy nested-bucket schema into the flat
+// volumes/libraries schema. It is idempotent: once the legacy buckets are
+// gone it only creates the current buckets if they are missing.
+func migrate(tx *bbolt.Tx) error {
+	volumesBkt, err := tx.CreateBucketIfNotExists([]byte(VolumesBucket))
+	if err != nil {
+		return fmt.Errorf("could not create bucket %s: %w", VolumesBucket, err)
+	}
+	librariesBkt, err := tx.CreateBucketIfNotExists([]byte(LibrariesBucket))
+	if err != nil {
+		return fmt.Errorf("could not create bucket %s: %w", LibrariesBucket, err)
+	}
 
-		// libraryToPackage lets us project the per-library volume count
-		// from LibraryMappingBucket onto a per-package count via
-		// LibraryMetadataBucket.
-		libraryToPackage := map[string]string{}
-		if metaBkt != nil {
-			if err := metaBkt.ForEach(func(k, v []byte) error {
-				var meta libraryMetadata
-				if err := json.Unmarshal(v, &meta); err != nil {
-					return fmt.Errorf("could not unmarshal library metadata: %w", err)
-				}
-				db.cachedLibrariesByPackage[meta.Package]++
-				db.cachedBytesByPackage[meta.Package] += meta.SizeBytes
-				libraryToPackage[string(k)] = meta.Package
-				return nil
-			}); err != nil {
-				return err
+	// Seed library records from the legacy metadata bucket.
+	if metaBkt := tx.Bucket([]byte(legacyLibraryMetadataBucket)); metaBkt != nil {
+		if err := metaBkt.ForEach(func(k, v []byte) error {
+			var meta struct {
+				Package   string `json:"package,omitempty"`
+				SizeBytes int64  `json:"size_bytes,omitempty"`
 			}
-		}
-
-		if mappingBkt == nil {
-			return nil
-		}
-		return mappingBkt.ForEachBucket(func(libraryKey []byte) error {
-			pkg, ok := libraryToPackage[string(libraryKey)]
-			if !ok {
-				// Library is on disk but predates the metadata bucket;
-				// we skip it (no package label available).
-				return nil
+			if err := json.Unmarshal(v, &meta); err != nil {
+				return fmt.Errorf("could not unmarshal legacy library metadata: %w", err)
 			}
-			libraryBkt := mappingBkt.Bucket(libraryKey)
-			if libraryBkt == nil {
-				return nil
-			}
-			return libraryBkt.ForEach(func(_, _ []byte) error {
-				db.volumeLinksByPackage[pkg]++
-				return nil
+			return putLibrary(librariesBkt, string(k), libraryRecord{
+				Package:   meta.Package,
+				SizeBytes: meta.SizeBytes,
 			})
-		})
-	})
+		}); err != nil {
+			return err
+		}
+	}
+
+	// Rebuild volume records and volume counts from the legacy mapping bucket.
+	if mappingBkt := tx.Bucket([]byte(legacyLibraryMappingBucket)); mappingBkt != nil {
+		if err := mappingBkt.ForEachBucket(func(libraryKey []byte) error {
+			libraryID := string(libraryKey)
+			libBkt := mappingBkt.Bucket(libraryKey)
+			if libBkt == nil {
+				return nil
+			}
+			return libBkt.ForEach(func(volumeKey, _ []byte) error {
+				if err := putVolume(volumesBkt, string(volumeKey), volumeRecord{LibraryID: libraryID}); err != nil {
+					return err
+				}
+				rec, err := getLibrary(librariesBkt, libraryID)
+				if err != nil {
+					return err
+				}
+				rec.VolumeCount++
+				return putLibrary(librariesBkt, libraryID, rec)
+			})
+		}); err != nil {
+			return err
+		}
+	}
+
+	// Drop the legacy buckets now that their content has been migrated.
+	for _, name := range []string{legacyLibraryMappingBucket, legacyVolumeMappingBucket, legacyLibraryMetadataBucket} {
+		if tx.Bucket([]byte(name)) != nil {
+			if err := tx.DeleteBucket([]byte(name)); err != nil {
+				return fmt.Errorf("could not delete legacy bucket %s: %w", name, err)
+			}
+		}
+	}
+
+	return nil
 }
 
-// Close will clean up the database and should be called before exiting.
+// Close cleans up the database and should be called before exiting.
 func (db *Database) Close() error {
 	return db.bbolt.Close()
 }
 
-// AddLibrary records a freshly-cached library: it persists the metadata
-// (package name + on-disk size) in LibraryMetadataBucket and updates the
-// in-memory aggregates. AddLibrary is the canonical writer for library
-// metadata; LinkVolume relies on it having been called first so that
-// per-package gauges have the right package name.
-//
-// AddLibrary is idempotent: calling it twice for the same library overwrites
-// the previous metadata (useful if the size changed) but does not
-// double-count it in the aggregates.
+// AddLibrary records a freshly-cached library by persisting its package name
+// and on-disk size. It is idempotent and preserves the volume count of an
+// existing record, so it can safely be called again (for instance when the
+// size changed) without disturbing the link bookkeeping.
 func (db *Database) AddLibrary(libraryID, packageName string, sizeBytes int64) error {
 	if libraryID == "" {
 		return fmt.Errorf("library ID cannot be blank")
@@ -200,475 +194,298 @@ func (db *Database) AddLibrary(libraryID, packageName string, sizeBytes int64) e
 		return fmt.Errorf("package name cannot be blank")
 	}
 
-	tx, err := db.bbolt.Begin(true)
-	if err != nil {
-		return fmt.Errorf("could not start transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	bkt := tx.Bucket([]byte(LibraryMetadataBucket))
-	if bkt == nil {
-		return fmt.Errorf("library metadata bucket does not exist")
-	}
-
-	// Preserve idempotency: if the library is already recorded we must
-	// subtract the previous size from the aggregates before adding the
-	// new one.
-	var previous libraryMetadata
-	if raw := bkt.Get([]byte(libraryID)); raw != nil {
-		if err := json.Unmarshal(raw, &previous); err != nil {
-			return fmt.Errorf("could not unmarshal existing library metadata: %w", err)
+	return db.bbolt.Update(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibrariesBucket))
+		if bkt == nil {
+			return fmt.Errorf("libraries bucket does not exist")
 		}
-	}
-
-	meta := libraryMetadata{Package: packageName, SizeBytes: sizeBytes}
-	encoded, err := json.Marshal(&meta)
-	if err != nil {
-		return fmt.Errorf("could not marshal library metadata: %w", err)
-	}
-	if err := bkt.Put([]byte(libraryID), encoded); err != nil {
-		return fmt.Errorf("could not write library metadata: %w", err)
-	}
-
-	db.cacheMu.Lock()
-	if previous.Package != "" {
-		db.cachedLibrariesByPackage[previous.Package]--
-		db.cachedBytesByPackage[previous.Package] -= previous.SizeBytes
-		if db.cachedLibrariesByPackage[previous.Package] <= 0 {
-			delete(db.cachedLibrariesByPackage, previous.Package)
-			delete(db.cachedBytesByPackage, previous.Package)
+		rec, err := getLibrary(bkt, libraryID)
+		if err != nil {
+			return err
 		}
-	}
-	db.cachedLibrariesByPackage[packageName]++
-	db.cachedBytesByPackage[packageName] += sizeBytes
-	if err := tx.Commit(); err != nil {
-		db.cacheMu.Unlock()
-		return fmt.Errorf("could not commit transaction: %w", err)
-	}
-	db.cacheMu.Unlock()
-
-	return nil
+		rec.Package = packageName
+		rec.SizeBytes = sizeBytes
+		return putLibrary(bkt, libraryID, rec)
+	})
 }
 
-// RemoveLibrary removes the metadata for a library and decrements the
-// in-memory aggregates accordingly. It is a no-op if the library has no
-// metadata recorded.
+// RemoveLibrary deletes the record for a library. It is a no-op when the
+// library is unknown.
 func (db *Database) RemoveLibrary(libraryID string) error {
 	if libraryID == "" {
 		return fmt.Errorf("library ID cannot be blank")
 	}
 
-	tx, err := db.bbolt.Begin(true)
-	if err != nil {
-		return fmt.Errorf("could not start transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	bkt := tx.Bucket([]byte(LibraryMetadataBucket))
-	if bkt == nil {
-		return fmt.Errorf("library metadata bucket does not exist")
-	}
-
-	raw := bkt.Get([]byte(libraryID))
-	if raw == nil {
-		return nil
-	}
-	var meta libraryMetadata
-	if err := json.Unmarshal(raw, &meta); err != nil {
-		return fmt.Errorf("could not unmarshal library metadata: %w", err)
-	}
-	if err := bkt.Delete([]byte(libraryID)); err != nil {
-		return fmt.Errorf("could not delete library metadata: %w", err)
-	}
-
-	db.cacheMu.Lock()
-	db.cachedLibrariesByPackage[meta.Package]--
-	db.cachedBytesByPackage[meta.Package] -= meta.SizeBytes
-	if db.cachedLibrariesByPackage[meta.Package] <= 0 {
-		delete(db.cachedLibrariesByPackage, meta.Package)
-		delete(db.cachedBytesByPackage, meta.Package)
-	}
-	if err := tx.Commit(); err != nil {
-		db.cacheMu.Unlock()
-		return fmt.Errorf("could not commit transaction: %w", err)
-	}
-	db.cacheMu.Unlock()
-
-	return nil
-}
-
-// PackageCacheStats returns the current cached-library count and the total
-// on-disk size, in bytes, for a given package name. Both values are zero
-// when the package has no cached library.
-func (db *Database) PackageCacheStats(packageName string) (int, int64) {
-	db.cacheMu.Lock()
-	defer db.cacheMu.Unlock()
-	return db.cachedLibrariesByPackage[packageName], db.cachedBytesByPackage[packageName]
-}
-
-// VolumeLinkCount returns the number of volumes currently linked to any
-// library of the given package.
-func (db *Database) VolumeLinkCount(packageName string) int {
-	db.cacheMu.Lock()
-	defer db.cacheMu.Unlock()
-	return db.volumeLinksByPackage[packageName]
-}
-
-// PackageForLibrary returns the package name recorded for a library, or an
-// empty string when the library has no metadata (for instance because it
-// was added by an older driver version that did not yet persist
-// per-library metadata).
-func (db *Database) PackageForLibrary(libraryID string) (string, error) {
-	if libraryID == "" {
-		return "", fmt.Errorf("library ID cannot be blank")
-	}
-
-	var pkg string
-	err := db.bbolt.View(func(tx *bbolt.Tx) error {
-		bkt := tx.Bucket([]byte(LibraryMetadataBucket))
+	return db.bbolt.Update(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibrariesBucket))
 		if bkt == nil {
+			return fmt.Errorf("libraries bucket does not exist")
+		}
+		return bkt.Delete([]byte(libraryID))
+	})
+}
+
+// LinkVolume records that volumeID uses libraryID and increments the
+// library's volume count. It is idempotent: linking an already-linked volume
+// is a no-op.
+func (db *Database) LinkVolume(libraryID, volumeID string) error {
+	if libraryID == "" {
+		return fmt.Errorf("library ID cannot be blank")
+	}
+	if volumeID == "" {
+		return fmt.Errorf("volume ID cannot be blank")
+	}
+
+	return db.bbolt.Update(func(tx *bbolt.Tx) error {
+		volumesBkt := tx.Bucket([]byte(VolumesBucket))
+		librariesBkt := tx.Bucket([]byte(LibrariesBucket))
+		if volumesBkt == nil || librariesBkt == nil {
+			return fmt.Errorf("database buckets do not exist")
+		}
+
+		// If the volume is already tracked there is nothing to do; skip the
+		// write and the count update to keep the operation idempotent.
+		if _, linked, err := getVolume(volumesBkt, volumeID); err != nil {
+			return err
+		} else if linked {
 			return nil
+		}
+
+		if err := putVolume(volumesBkt, volumeID, volumeRecord{LibraryID: libraryID}); err != nil {
+			return err
+		}
+		rec, err := getLibrary(librariesBkt, libraryID)
+		if err != nil {
+			return err
+		}
+		rec.VolumeCount++
+		return putLibrary(librariesBkt, libraryID, rec)
+	})
+}
+
+// UnlinkVolume removes the link for a volume and decrements the owning
+// library's volume count. It returns the library ID and package name the
+// volume was linked to (both empty when the volume was not tracked, in which
+// case it is a no-op). The package is read off the library record that is
+// loaded to decrement the count, so callers get the metric label for free
+// without an extra lookup.
+func (db *Database) UnlinkVolume(volumeID string) (libraryID, packageName string, err error) {
+	if volumeID == "" {
+		return "", "", fmt.Errorf("volume ID cannot be blank")
+	}
+
+	err = db.bbolt.Update(func(tx *bbolt.Tx) error {
+		volumesBkt := tx.Bucket([]byte(VolumesBucket))
+		librariesBkt := tx.Bucket([]byte(LibrariesBucket))
+		if volumesBkt == nil || librariesBkt == nil {
+			return fmt.Errorf("database buckets do not exist")
+		}
+
+		rec, linked, err := getVolume(volumesBkt, volumeID)
+		if err != nil {
+			return err
+		}
+		if !linked {
+			return nil
+		}
+		libraryID = rec.LibraryID
+
+		if err := volumesBkt.Delete([]byte(volumeID)); err != nil {
+			return fmt.Errorf("could not delete volume record %s: %w", volumeID, err)
+		}
+
+		libRec, err := getLibrary(librariesBkt, libraryID)
+		if err != nil {
+			return err
+		}
+		packageName = libRec.Package
+		if libRec.VolumeCount > 0 {
+			libRec.VolumeCount--
+			if err := putLibrary(librariesBkt, libraryID, libRec); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+	return libraryID, packageName, nil
+}
+
+// GetLibraryForVolume returns the library ID a volume is linked to, or an
+// empty string when the volume is not tracked.
+func (db *Database) GetLibraryForVolume(volumeID string) (string, error) {
+	if volumeID == "" {
+		return "", fmt.Errorf("volume ID cannot be blank")
+	}
+
+	var libraryID string
+	err := db.bbolt.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(VolumesBucket))
+		if bkt == nil {
+			return fmt.Errorf("volumes bucket does not exist")
+		}
+		rec, _, err := getVolume(bkt, volumeID)
+		if err != nil {
+			return err
+		}
+		libraryID = rec.LibraryID
+		return nil
+	})
+	return libraryID, err
+}
+
+// GetLibrary returns the stored information for a library. The boolean is
+// false when the library has no record (for instance a legacy entry on disk
+// that was never tracked with metadata).
+func (db *Database) GetLibrary(libraryID string) (LibraryInfo, bool, error) {
+	if libraryID == "" {
+		return LibraryInfo{}, false, fmt.Errorf("library ID cannot be blank")
+	}
+
+	var (
+		info  LibraryInfo
+		found bool
+	)
+	err := db.bbolt.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibrariesBucket))
+		if bkt == nil {
+			return fmt.Errorf("libraries bucket does not exist")
 		}
 		raw := bkt.Get([]byte(libraryID))
 		if raw == nil {
 			return nil
 		}
-		var meta libraryMetadata
-		if err := json.Unmarshal(raw, &meta); err != nil {
-			return fmt.Errorf("could not unmarshal library metadata: %w", err)
+		var rec libraryRecord
+		if err := json.Unmarshal(raw, &rec); err != nil {
+			return fmt.Errorf("could not unmarshal library record: %w", err)
 		}
-		pkg = meta.Package
+		found = true
+		info = LibraryInfo{Package: rec.Package, SizeBytes: rec.SizeBytes, VolumeCount: rec.VolumeCount}
 		return nil
 	})
-	return pkg, err
+	return info, found, err
 }
 
-// Snapshot returns a consistent snapshot of every aggregate the listener
-// needs to publish gauges. The returned maps are owned by the caller and
-// safe to retain.
-func (db *Database) Snapshot() libraryevents.Snapshot {
-	db.cacheMu.Lock()
-	defer db.cacheMu.Unlock()
-	cachedCount := make(map[string]int, len(db.cachedLibrariesByPackage))
-	for pkg, n := range db.cachedLibrariesByPackage {
-		cachedCount[pkg] = n
+// Snapshot derives the per-package aggregates the metrics listener needs by
+// scanning LibrariesBucket. It is cheap because a node only ever caches a
+// small number of libraries. Libraries without a package label (legacy
+// entries) are left out because they were never published as gauges.
+func (db *Database) Snapshot() (libraryevents.Snapshot, error) {
+	snap := libraryevents.Snapshot{
+		CachedCountByLibrary: map[string]int{},
+		CachedBytesByLibrary: map[string]int64{},
+		VolumeLinksByLibrary: map[string]int{},
 	}
-	cachedBytes := make(map[string]int64, len(db.cachedBytesByPackage))
-	for pkg, n := range db.cachedBytesByPackage {
-		cachedBytes[pkg] = n
-	}
-	volumeLinks := make(map[string]int, len(db.volumeLinksByPackage))
-	for pkg, n := range db.volumeLinksByPackage {
-		volumeLinks[pkg] = n
-	}
-	return libraryevents.Snapshot{
-		CachedCountByLibrary: cachedCount,
-		CachedBytesByLibrary: cachedBytes,
-		VolumeLinksByLibrary: volumeLinks,
-	}
-}
-
-// LinkVolume creates a bidrectional mapping between the library and volume.
-// When per-library metadata is recorded (i.e. AddLibrary has been called
-// before LinkVolume), the per-package volume-links aggregate is updated
-// atomically with the bbolt transaction.
-func (db *Database) LinkVolume(libraryID string, volumeID string) error {
-	// Validate input.
-	if libraryID == "" {
-		return fmt.Errorf("library ID cannot be blank")
-	}
-	if volumeID == "" {
-		return fmt.Errorf("volume ID cannot be blank")
-	}
-
-	// Start a transaction.
-	tx, err := db.bbolt.Begin(true)
-	if err != nil {
-		return fmt.Errorf("could not start transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
-	libraryMappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
-	if libraryMappingBkt == nil {
-		return fmt.Errorf("library mapping bucket does not exist")
-	}
-
-	// Get the bucket for volume mappings. If it doesn't exist, we have a system level issue.
-	volumeMappingBkt := tx.Bucket([]byte(VolumeMappingBucket))
-	if volumeMappingBkt == nil {
-		return fmt.Errorf("volume mapping bucket does not exist")
-	}
-
-	// Create the bucket for the library if it does not exist.
-	libraryBkt, err := libraryMappingBkt.CreateBucketIfNotExists([]byte(libraryID))
-	if err != nil {
-		return fmt.Errorf("could not create bucket for library %s: %w", libraryID, err)
-	}
-
-	// If the volume is already linked there is nothing to do; skip the
-	// extra writes and the aggregate update.
-	if libraryBkt.Get([]byte(volumeID)) != nil {
-		return nil
-	}
-
-	// Create the bucket for the volume if it does not exist.
-	volumeBkt, err := volumeMappingBkt.CreateBucketIfNotExists([]byte(volumeID))
-	if err != nil {
-		return fmt.Errorf("could not create bucket for volume %s: %w", volumeID, err)
-	}
-
-	// The linked volume is intentially empty at the moment with the expectation that we can add fields at a later
-	// point in time without breaking existing databases.
-	lp, err := json.Marshal(&linkedVolume{})
-	if err != nil {
-		return fmt.Errorf("could not marshal linked volume info: %w", err)
-	}
-
-	// The linked library is intentially empty at the moment with the expectation that we can add fields at a later
-	// point in time without breaking existing databases.
-	ll, err := json.Marshal(&linkedLibrary{})
-	if err != nil {
-		return fmt.Errorf("could not marshal linked library info: %w", err)
-	}
-
-	// Link the volume to the library.
-	err = libraryBkt.Put([]byte(volumeID), lp)
-	if err != nil {
-		return fmt.Errorf("could not assign volume with id %s: %w", volumeID, err)
-	}
-
-	// Link the library to the volume.
-	err = volumeBkt.Put([]byte(libraryID), ll)
-	if err != nil {
-		return fmt.Errorf("could not assign volume with id %s: %w", volumeID, err)
-	}
-
-	// Look up the package name now, while the transaction is still open
-	// and we have a consistent view. The lookup falls back to an empty
-	// string for libraries that predate the metadata bucket.
-	packageName, err := packageForLibraryInTx(tx, libraryID)
-	if err != nil {
-		return err
-	}
-
-	// Take cacheMu just long enough to update the aggregate and commit so
-	// readers never observe a state where bbolt and the in-memory cache
-	// disagree.
-	db.cacheMu.Lock()
-	if packageName != "" {
-		db.volumeLinksByPackage[packageName]++
-	}
-	if err := tx.Commit(); err != nil {
-		if packageName != "" {
-			db.volumeLinksByPackage[packageName]--
+	err := db.bbolt.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibrariesBucket))
+		if bkt == nil {
+			return nil
 		}
-		db.cacheMu.Unlock()
-		return fmt.Errorf("could not commit transaction: %w", err)
+		return bkt.ForEach(func(_, v []byte) error {
+			var rec libraryRecord
+			if err := json.Unmarshal(v, &rec); err != nil {
+				return fmt.Errorf("could not unmarshal library record: %w", err)
+			}
+			if rec.Package == "" {
+				return nil
+			}
+			snap.CachedCountByLibrary[rec.Package]++
+			snap.CachedBytesByLibrary[rec.Package] += rec.SizeBytes
+			snap.VolumeLinksByLibrary[rec.Package] += rec.VolumeCount
+			return nil
+		})
+	})
+	if err != nil {
+		return libraryevents.Snapshot{}, err
 	}
-	db.cacheMu.Unlock()
-
-	return nil
+	return snap, nil
 }
 
-// packageForLibraryInTx is the transaction-bound flavour of PackageForLibrary
-// used internally by LinkVolume/UnlinkVolume to keep the aggregate update
-// consistent with the bbolt write.
-func packageForLibraryInTx(tx *bbolt.Tx, libraryID string) (string, error) {
-	bkt := tx.Bucket([]byte(LibraryMetadataBucket))
-	if bkt == nil {
-		return "", nil
+// PackageStats returns the per-package aggregates for a single package: the
+// number of cached versions, their cumulative on-disk size in bytes, and the
+// number of volumes linked to any of them. It scans LibrariesBucket, which is
+// cheap because a node only ever caches a handful of libraries. It is the
+// per-package counterpart of Snapshot, used to label the gauge events the
+// manager emits on each state change.
+func (db *Database) PackageStats(packageName string) (cachedCount int, cachedBytes int64, volumeLinks int, err error) {
+	if packageName == "" {
+		return 0, 0, 0, nil
 	}
+	err = db.bbolt.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(LibrariesBucket))
+		if bkt == nil {
+			return nil
+		}
+		return bkt.ForEach(func(_, v []byte) error {
+			var rec libraryRecord
+			if err := json.Unmarshal(v, &rec); err != nil {
+				return fmt.Errorf("could not unmarshal library record: %w", err)
+			}
+			if rec.Package != packageName {
+				return nil
+			}
+			cachedCount++
+			cachedBytes += rec.SizeBytes
+			volumeLinks += rec.VolumeCount
+			return nil
+		})
+	})
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return cachedCount, cachedBytes, volumeLinks, nil
+}
+
+// getLibrary reads and decodes a library record. A missing key yields a zero
+// record and no error so callers can treat it as an upsert base.
+func getLibrary(bkt *bbolt.Bucket, libraryID string) (libraryRecord, error) {
+	var rec libraryRecord
 	raw := bkt.Get([]byte(libraryID))
 	if raw == nil {
-		return "", nil
+		return rec, nil
 	}
-	var meta libraryMetadata
-	if err := json.Unmarshal(raw, &meta); err != nil {
-		return "", fmt.Errorf("could not unmarshal library metadata: %w", err)
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return rec, fmt.Errorf("could not unmarshal library record: %w", err)
 	}
-	return meta.Package, nil
+	return rec, nil
 }
 
-// UnlinkVolume removes the link for a given volume.
-// When the link existed and per-library metadata is recorded, the
-// per-package volume-links aggregate is decremented atomically with the
-// bbolt transaction.
-func (db *Database) UnlinkVolume(libraryID string, volumeID string) error {
-	// Validate input.
-	if libraryID == "" {
-		return fmt.Errorf("library ID cannot be blank")
-	}
-	if volumeID == "" {
-		return fmt.Errorf("volume ID cannot be blank")
-	}
-
-	// Start a transaction.
-	tx, err := db.bbolt.Begin(true)
+// putLibrary encodes and writes a library record.
+func putLibrary(bkt *bbolt.Bucket, libraryID string, rec libraryRecord) error {
+	encoded, err := json.Marshal(&rec)
 	if err != nil {
-		return fmt.Errorf("could not start transaction: %w", err)
+		return fmt.Errorf("could not marshal library record: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
-	libraryMappingBkt := tx.Bucket([]byte(LibraryMappingBucket))
-	if libraryMappingBkt == nil {
-		return fmt.Errorf("library mapping bucket does not exist")
+	if err := bkt.Put([]byte(libraryID), encoded); err != nil {
+		return fmt.Errorf("could not write library record: %w", err)
 	}
-
-	// Get the bucket for volume mappings. If it doesn't exist, we have a system level issue.
-	volumeMappingBkt := tx.Bucket([]byte(VolumeMappingBucket))
-	if volumeMappingBkt == nil {
-		return fmt.Errorf("library mapping bucket does not exist")
-	}
-
-	// Detect whether the link actually existed so the aggregate is only
-	// decremented for a real removal.
-	wasLinked := false
-	if libraryBucket := libraryMappingBkt.Bucket([]byte(libraryID)); libraryBucket != nil {
-		wasLinked = libraryBucket.Get([]byte(volumeID)) != nil
-	}
-
-	// Check if the library bucket exists.
-	libraryBucket := libraryMappingBkt.Bucket([]byte(libraryID))
-	if libraryBucket != nil {
-		// Delete the volume for library. Will return nil if the key does not exist and only returns an error if there was an issue.
-		err = libraryBucket.Delete([]byte(volumeID))
-		if err != nil {
-			return fmt.Errorf("could not delete library mapping for volume %s: %w", volumeID, err)
-		}
-
-		// If there are no more mappings for this library, delete the bucket.
-		c := libraryBucket.Cursor()
-		key, _ := c.First()
-		if key == nil {
-			err = libraryMappingBkt.DeleteBucket([]byte(libraryID))
-			if err != nil {
-				return fmt.Errorf("could not delete empty bucket for library %s: %w", libraryID, err)
-			}
-		}
-	}
-
-	// Check if the volume bucket exists.
-	volumeBucket := volumeMappingBkt.Bucket([]byte(volumeID))
-	if volumeBucket != nil {
-		// Delete the library for volume. Will return nil if the key does not exist and only returns an error if there was an issue.
-		err = volumeBucket.Delete([]byte(libraryID))
-		if err != nil {
-			return fmt.Errorf("could not delete volume mapping for library %s: %w", libraryID, err)
-		}
-
-		// If there are no more mappings for this volume, delete the bucket.
-		c := volumeBucket.Cursor()
-		key, _ := c.First()
-		if key == nil {
-			err = volumeMappingBkt.DeleteBucket([]byte(volumeID))
-			if err != nil {
-				return fmt.Errorf("could not delete empty bucket for volume %s: %w", volumeID, err)
-			}
-		}
-	}
-
-	// Look up the package while the transaction is still open so the
-	// aggregate update is consistent with the bbolt write.
-	packageName := ""
-	if wasLinked {
-		packageName, err = packageForLibraryInTx(tx, libraryID)
-		if err != nil {
-			return err
-		}
-	}
-
-	db.cacheMu.Lock()
-	if packageName != "" {
-		db.volumeLinksByPackage[packageName]--
-		if db.volumeLinksByPackage[packageName] <= 0 {
-			delete(db.volumeLinksByPackage, packageName)
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		if packageName != "" {
-			db.volumeLinksByPackage[packageName]++
-		}
-		db.cacheMu.Unlock()
-		return fmt.Errorf("could not commit transaction: %w", err)
-	}
-	db.cacheMu.Unlock()
-
 	return nil
 }
 
-// GetVolumeCount returns the number of volumes linked to a library.
-func (db *Database) GetVolumeCount(libraryID string) (int, error) {
-	// Validate input.
-	if libraryID == "" {
-		return 0, fmt.Errorf("library ID cannot be blank")
+// getVolume reads and decodes a volume record. The boolean reports whether
+// the record exists.
+func getVolume(bkt *bbolt.Bucket, volumeID string) (volumeRecord, bool, error) {
+	var rec volumeRecord
+	raw := bkt.Get([]byte(volumeID))
+	if raw == nil {
+		return rec, false, nil
 	}
-
-	// Start a transaction.
-	tx, err := db.bbolt.Begin(false)
-	if err != nil {
-		return 0, fmt.Errorf("could not start transaction: %w", err)
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return rec, false, fmt.Errorf("could not unmarshal volume record: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Get the bucket for library mappings. If it doesn't exist, we have a system level issue.
-	root := tx.Bucket([]byte(LibraryMappingBucket))
-	if root == nil {
-		return 0, fmt.Errorf("library mapping bucket does not exist")
-	}
-
-	// Get the bucket for the library. If it doesn't exist, then there are no linked volumes for the library.
-	bkt := root.Bucket([]byte(libraryID))
-	if bkt == nil {
-		return 0, nil
-	}
-
-	// Count the keys in the bucket.
-	count := 0
-	err = bkt.ForEach(func(k, v []byte) error {
-		count++
-		return nil
-	})
-	if err != nil {
-		return 0, fmt.Errorf("could not count volumes for library %s: %w", libraryID, err)
-	}
-
-	// Return number of volumes linked to the bucket.
-	return count, nil
+	return rec, true, nil
 }
 
-// GetLibraryForVolume returns the library mapped to a volume. A volume should only ever have one library mapped to it.
-func (db *Database) GetLibraryForVolume(volumeID string) (string, error) {
-	// Validate input.
-	if volumeID == "" {
-		return "", fmt.Errorf("volume ID cannot be blank")
-	}
-
-	// Start a transaction.
-	tx, err := db.bbolt.Begin(false)
+// putVolume encodes and writes a volume record.
+func putVolume(bkt *bbolt.Bucket, volumeID string, rec volumeRecord) error {
+	encoded, err := json.Marshal(&rec)
 	if err != nil {
-		return "", fmt.Errorf("could not start transaction: %w", err)
+		return fmt.Errorf("could not marshal volume record: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Get the bucket for volume mappings. If it doesn't exist, we have a system level issue.
-	root := tx.Bucket([]byte(VolumeMappingBucket))
-	if root == nil {
-		return "", fmt.Errorf("volume mapping bucket does not exist")
+	if err := bkt.Put([]byte(volumeID), encoded); err != nil {
+		return fmt.Errorf("could not write volume record: %w", err)
 	}
-
-	// Get the bucket for the volume. If it doesn't exist, then there are no linked libraries for the volume.
-	bkt := root.Bucket([]byte(volumeID))
-	if bkt == nil {
-		return "", nil
-	}
-
-	c := bkt.Cursor()
-	key, _ := c.First()
-	if key == nil {
-		return "", nil
-	}
-
-	return string(key), nil
+	return nil
 }

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -30,7 +30,7 @@ func volumeCount(t *testing.T, db *librarymanager.Database, libraryID string) in
 // are exercised explicitly by TestDatabaseRelinkVolumeToDifferentLibrary).
 func link(t *testing.T, db *librarymanager.Database, libraryID, volumeID string) {
 	t.Helper()
-	_, err := db.LinkVolume(libraryID, volumeID)
+	_, err := db.LinkVolume(libraryID, volumeID, false)
 	require.NoError(t, err)
 }
 
@@ -61,7 +61,7 @@ func TestDatabase(t *testing.T) {
 	require.Empty(t, pkg, "unlinking an unknown volume reports no package")
 
 	// Ensure a linked volume is linked.
-	_, err = db.LinkVolume(libraryID, volumeID)
+	_, err = db.LinkVolume(libraryID, volumeID, false)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestDatabase(t *testing.T) {
 	require.Equal(t, 1, volumeCount(t, db, libraryID), "there should be one volume linked")
 
 	// Ensure a second call to link the same volume does nothing.
-	_, err = db.LinkVolume(libraryID, volumeID)
+	_, err = db.LinkVolume(libraryID, volumeID, false)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestDatabase(t *testing.T) {
 
 	// Ensure a second linked volume shows both.
 	secondVolumeID := "test-volume-id-two"
-	_, err = db.LinkVolume(libraryID, secondVolumeID)
+	_, err = db.LinkVolume(libraryID, secondVolumeID, false)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -297,7 +297,7 @@ func TestDatabaseRelinkVolumeToDifferentLibrary(t *testing.T) {
 
 	// Link the volume to the old library first. A fresh link reports no
 	// previous library.
-	previous, err := db.LinkVolume("old-lib", "vol-1")
+	previous, err := db.LinkVolume("old-lib", "vol-1", false)
 	require.NoError(t, err)
 	require.Empty(t, previous, "a fresh link has no previous library")
 	require.Equal(t, 1, volumeCount(t, db, "old-lib"))
@@ -307,7 +307,7 @@ func TestDatabaseRelinkVolumeToDifferentLibrary(t *testing.T) {
 	// the volume now maps to the new library, the old count is decremented,
 	// and the displaced library is reported so the caller can schedule its
 	// cleanup.
-	previous, err = db.LinkVolume("new-lib", "vol-1")
+	previous, err = db.LinkVolume("new-lib", "vol-1", true)
 	require.NoError(t, err)
 	require.Equal(t, "old-lib", previous, "transfer reports the displaced library")
 	lib, err := db.GetLibraryForVolume("vol-1")

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -25,6 +25,15 @@ func volumeCount(t *testing.T, db *librarymanager.Database, libraryID string) in
 	return info.VolumeCount
 }
 
+// link is a small helper to link a volume and assert success, discarding the
+// previous-library return value that only matters in transfer scenarios (which
+// are exercised explicitly by TestDatabaseRelinkVolumeToDifferentLibrary).
+func link(t *testing.T, db *librarymanager.Database, libraryID, volumeID string) {
+	t.Helper()
+	_, err := db.LinkVolume(libraryID, volumeID)
+	require.NoError(t, err)
+}
+
 func TestDatabase(t *testing.T) {
 	// Create scratch space.
 	tsd := testutil.NewTempScratchDirectory(t)
@@ -52,7 +61,7 @@ func TestDatabase(t *testing.T) {
 	require.Empty(t, pkg, "unlinking an unknown volume reports no package")
 
 	// Ensure a linked volume is linked.
-	err = db.LinkVolume(libraryID, volumeID)
+	_, err = db.LinkVolume(libraryID, volumeID)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -60,7 +69,7 @@ func TestDatabase(t *testing.T) {
 	require.Equal(t, 1, volumeCount(t, db, libraryID), "there should be one volume linked")
 
 	// Ensure a second call to link the same volume does nothing.
-	err = db.LinkVolume(libraryID, volumeID)
+	_, err = db.LinkVolume(libraryID, volumeID)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -69,7 +78,7 @@ func TestDatabase(t *testing.T) {
 
 	// Ensure a second linked volume shows both.
 	secondVolumeID := "test-volume-id-two"
-	err = db.LinkVolume(libraryID, secondVolumeID)
+	_, err = db.LinkVolume(libraryID, secondVolumeID)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -213,7 +222,7 @@ func TestDatabaseVolumeLinksAggregateByPackage(t *testing.T) {
 
 	// Without metadata the aggregate is not touched even after a link
 	// (a library without a package label is excluded from the snapshot).
-	require.NoError(t, db.LinkVolume("lib-id-1", "vol-1"))
+	link(t, db, "lib-id-1", "vol-1")
 	snap, err = db.Snapshot()
 	require.NoError(t, err)
 	require.Equal(t, 0, snap.VolumeLinksByLibrary["dd-lib-java-init"])
@@ -221,13 +230,13 @@ func TestDatabaseVolumeLinksAggregateByPackage(t *testing.T) {
 	// Once metadata is recorded, the aggregate reflects the links.
 	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 100))
 	require.NoError(t, db.AddLibrary("lib-id-2", "dd-lib-java-init", 200))
-	require.NoError(t, db.LinkVolume("lib-id-2", "vol-3"))
+	link(t, db, "lib-id-2", "vol-3")
 	snap, err = db.Snapshot()
 	require.NoError(t, err)
 	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 
 	// Re-linking the same volume is a no-op for the aggregate.
-	require.NoError(t, db.LinkVolume("lib-id-1", "vol-1"))
+	link(t, db, "lib-id-1", "vol-1")
 	snap, err = db.Snapshot()
 	require.NoError(t, err)
 	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
@@ -258,8 +267,8 @@ func TestDatabaseVolumeLinksReloadedFromDisk(t *testing.T) {
 	db, err := librarymanager.NewDatabase(tsd.Path(t))
 	require.NoError(t, err)
 	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 100))
-	require.NoError(t, db.LinkVolume("lib-id-1", "vol-1"))
-	require.NoError(t, db.LinkVolume("lib-id-1", "vol-2"))
+	link(t, db, "lib-id-1", "vol-1")
+	link(t, db, "lib-id-1", "vol-2")
 	require.NoError(t, db.Close())
 
 	db2, err := librarymanager.NewDatabase(tsd.Path(t))
@@ -286,14 +295,21 @@ func TestDatabaseRelinkVolumeToDifferentLibrary(t *testing.T) {
 	require.NoError(t, db.AddLibrary("old-lib", "dd-lib-java-init", 100))
 	require.NoError(t, db.AddLibrary("new-lib", "dd-lib-java-init", 200))
 
-	// Link the volume to the old library first.
-	require.NoError(t, db.LinkVolume("old-lib", "vol-1"))
+	// Link the volume to the old library first. A fresh link reports no
+	// previous library.
+	previous, err := db.LinkVolume("old-lib", "vol-1")
+	require.NoError(t, err)
+	require.Empty(t, previous, "a fresh link has no previous library")
 	require.Equal(t, 1, volumeCount(t, db, "old-lib"))
 	require.Equal(t, 0, volumeCount(t, db, "new-lib"))
 
 	// Re-linking the same volume to a different library transfers the link:
-	// the volume now maps to the new library and the old count is decremented.
-	require.NoError(t, db.LinkVolume("new-lib", "vol-1"))
+	// the volume now maps to the new library, the old count is decremented,
+	// and the displaced library is reported so the caller can schedule its
+	// cleanup.
+	previous, err = db.LinkVolume("new-lib", "vol-1")
+	require.NoError(t, err)
+	require.Equal(t, "old-lib", previous, "transfer reports the displaced library")
 	lib, err := db.GetLibraryForVolume("vol-1")
 	require.NoError(t, err)
 	require.Equal(t, "new-lib", lib)

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -25,13 +25,10 @@ func volumeCount(t *testing.T, db *librarymanager.Database, libraryID string) in
 	return info.VolumeCount
 }
 
-// link is a small helper to link a volume and assert success, discarding the
-// previous-library return value that only matters in transfer scenarios (which
-// are exercised explicitly by TestDatabaseRelinkVolumeToDifferentLibrary).
+// link is a small helper to link a volume and assert success.
 func link(t *testing.T, db *librarymanager.Database, libraryID, volumeID string) {
 	t.Helper()
-	_, err := db.LinkVolume(libraryID, volumeID, false)
-	require.NoError(t, err)
+	require.NoError(t, db.LinkVolume(libraryID, volumeID, false))
 }
 
 func TestDatabase(t *testing.T) {
@@ -61,7 +58,7 @@ func TestDatabase(t *testing.T) {
 	require.Empty(t, pkg, "unlinking an unknown volume reports no package")
 
 	// Ensure a linked volume is linked.
-	_, err = db.LinkVolume(libraryID, volumeID, false)
+	err = db.LinkVolume(libraryID, volumeID, false)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -69,7 +66,7 @@ func TestDatabase(t *testing.T) {
 	require.Equal(t, 1, volumeCount(t, db, libraryID), "there should be one volume linked")
 
 	// Ensure a second call to link the same volume does nothing.
-	_, err = db.LinkVolume(libraryID, volumeID, false)
+	err = db.LinkVolume(libraryID, volumeID, false)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -78,7 +75,7 @@ func TestDatabase(t *testing.T) {
 
 	// Ensure a second linked volume shows both.
 	secondVolumeID := "test-volume-id-two"
-	_, err = db.LinkVolume(libraryID, secondVolumeID, false)
+	err = db.LinkVolume(libraryID, secondVolumeID, false)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
@@ -278,50 +275,6 @@ func TestDatabaseVolumeLinksReloadedFromDisk(t *testing.T) {
 	snap, err := db2.Snapshot()
 	require.NoError(t, err)
 	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
-}
-
-// TestDatabaseRelinkVolumeToDifferentLibrary verifies that re-linking an
-// already-tracked volume to a different library (a volume re-published against
-// a new library/version without an intervening unlink) moves the link and
-// keeps both libraries' counts consistent.
-func TestDatabaseRelinkVolumeToDifferentLibrary(t *testing.T) {
-	tsd := testutil.NewTempScratchDirectory(t)
-	defer tsd.Cleanup(t)
-
-	db, err := librarymanager.NewDatabase(tsd.Path(t))
-	require.NoError(t, err)
-	defer db.Close()
-
-	require.NoError(t, db.AddLibrary("old-lib", "dd-lib-java-init", 100))
-	require.NoError(t, db.AddLibrary("new-lib", "dd-lib-java-init", 200))
-
-	// Link the volume to the old library first. A fresh link reports no
-	// previous library.
-	previous, err := db.LinkVolume("old-lib", "vol-1", false)
-	require.NoError(t, err)
-	require.Empty(t, previous, "a fresh link has no previous library")
-	require.Equal(t, 1, volumeCount(t, db, "old-lib"))
-	require.Equal(t, 0, volumeCount(t, db, "new-lib"))
-
-	// Re-linking the same volume to a different library transfers the link:
-	// the volume now maps to the new library, the old count is decremented,
-	// and the displaced library is reported so the caller can schedule its
-	// cleanup.
-	previous, err = db.LinkVolume("new-lib", "vol-1", true)
-	require.NoError(t, err)
-	require.Equal(t, "old-lib", previous, "transfer reports the displaced library")
-	lib, err := db.GetLibraryForVolume("vol-1")
-	require.NoError(t, err)
-	require.Equal(t, "new-lib", lib)
-	require.Equal(t, 0, volumeCount(t, db, "old-lib"), "old library is decremented on transfer")
-	require.Equal(t, 1, volumeCount(t, db, "new-lib"), "new library owns the volume")
-
-	// A subsequent unlink only affects the new (owning) library.
-	unlinked, _, err := db.UnlinkVolume("vol-1")
-	require.NoError(t, err)
-	require.Equal(t, "new-lib", unlinked)
-	require.Equal(t, 0, volumeCount(t, db, "old-lib"))
-	require.Equal(t, 0, volumeCount(t, db, "new-lib"))
 }
 
 // TestDatabaseMigrationDeduplicatesVolumeAcrossLibraries verifies that a

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -271,6 +271,90 @@ func TestDatabaseVolumeLinksReloadedFromDisk(t *testing.T) {
 	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 }
 
+// TestDatabaseRelinkVolumeToDifferentLibrary verifies that re-linking an
+// already-tracked volume to a different library (a volume re-published against
+// a new library/version without an intervening unlink) moves the link and
+// keeps both libraries' counts consistent.
+func TestDatabaseRelinkVolumeToDifferentLibrary(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.AddLibrary("old-lib", "dd-lib-java-init", 100))
+	require.NoError(t, db.AddLibrary("new-lib", "dd-lib-java-init", 200))
+
+	// Link the volume to the old library first.
+	require.NoError(t, db.LinkVolume("old-lib", "vol-1"))
+	require.Equal(t, 1, volumeCount(t, db, "old-lib"))
+	require.Equal(t, 0, volumeCount(t, db, "new-lib"))
+
+	// Re-linking the same volume to a different library transfers the link:
+	// the volume now maps to the new library and the old count is decremented.
+	require.NoError(t, db.LinkVolume("new-lib", "vol-1"))
+	lib, err := db.GetLibraryForVolume("vol-1")
+	require.NoError(t, err)
+	require.Equal(t, "new-lib", lib)
+	require.Equal(t, 0, volumeCount(t, db, "old-lib"), "old library is decremented on transfer")
+	require.Equal(t, 1, volumeCount(t, db, "new-lib"), "new library owns the volume")
+
+	// A subsequent unlink only affects the new (owning) library.
+	unlinked, _, err := db.UnlinkVolume("vol-1")
+	require.NoError(t, err)
+	require.Equal(t, "new-lib", unlinked)
+	require.Equal(t, 0, volumeCount(t, db, "old-lib"))
+	require.Equal(t, 0, volumeCount(t, db, "new-lib"))
+}
+
+// TestDatabaseMigrationDeduplicatesVolumeAcrossLibraries verifies that a
+// legacy database which mapped the same volume under more than one library
+// (possible because the legacy LinkVolume only checked the per-library bucket)
+// migrates the volume exactly once, so the owning library carries the only
+// count and the others are left at zero and remain cleanable.
+func TestDatabaseMigrationDeduplicatesVolumeAcrossLibraries(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	dbPath := filepath.Join(tsd.Path(t), librarymanager.DatabaseFileName)
+
+	legacy, err := bbolt.Open(dbPath, 0600, nil)
+	require.NoError(t, err)
+	require.NoError(t, legacy.Update(func(tx *bbolt.Tx) error {
+		mappings, err := tx.CreateBucketIfNotExists([]byte("library-mappings"))
+		if err != nil {
+			return err
+		}
+		// The same volume appears under two libraries.
+		for _, libID := range []string{"lib-a", "lib-b"} {
+			libBkt, err := mappings.CreateBucketIfNotExists([]byte(libID))
+			if err != nil {
+				return err
+			}
+			if err := libBkt.Put([]byte("shared-vol"), []byte("{}")); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+	require.NoError(t, legacy.Close())
+
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+	defer db.Close()
+
+	// The volume maps to exactly one library.
+	lib, err := db.GetLibraryForVolume("shared-vol")
+	require.NoError(t, err)
+	require.Contains(t, []string{"lib-a", "lib-b"}, lib)
+
+	// The shared volume is counted exactly once, by the owning library only.
+	require.Equal(t, 1, volumeCount(t, db, "lib-a")+volumeCount(t, db, "lib-b"),
+		"the shared volume is counted exactly once across libraries")
+	require.Equal(t, 1, volumeCount(t, db, lib), "the owning library carries the only count")
+}
+
 // TestDatabaseMigratesLegacySchema seeds a database with the legacy
 // nested-bucket schema (library-mappings/volume-mappings/library-metadata)
 // and verifies NewDatabase rewrites it into the flat volumes/libraries schema

--- a/pkg/librarymanager/db_test.go
+++ b/pkg/librarymanager/db_test.go
@@ -6,12 +6,24 @@
 package librarymanager_test
 
 import (
+	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
 	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 )
+
+// volumeCount is a small helper to read the live volume count of a library
+// through the public GetLibrary accessor.
+func volumeCount(t *testing.T, db *librarymanager.Database, libraryID string) int {
+	t.Helper()
+	info, _, err := db.GetLibrary(libraryID)
+	require.NoError(t, err)
+	return info.VolumeCount
+}
 
 func TestDatabase(t *testing.T) {
 	// Create scratch space.
@@ -31,13 +43,13 @@ func TestDatabase(t *testing.T) {
 
 	// Ensure there are no libraries linked when none have been linked.
 	libraryID := "test-library-id"
-	count, err := db.GetVolumeCount(libraryID)
-	require.NoError(t, err)
-	require.Equal(t, 0, count, "there should be no volumes linked")
+	require.Equal(t, 0, volumeCount(t, db, libraryID), "there should be no volumes linked")
 
 	// Ensure that an unlink does not produce an error if it has not been linked.
-	err = db.UnlinkVolume(libraryID, volumeID)
+	unlinked, pkg, err := db.UnlinkVolume(volumeID)
 	require.NoError(t, err)
+	require.Empty(t, unlinked, "unlinking an unknown volume reports no library")
+	require.Empty(t, pkg, "unlinking an unknown volume reports no package")
 
 	// Ensure a linked volume is linked.
 	err = db.LinkVolume(libraryID, volumeID)
@@ -45,19 +57,15 @@ func TestDatabase(t *testing.T) {
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
 	require.Equal(t, libraryID, lib, "there should be a library linked")
-	count, err = db.GetVolumeCount(libraryID)
-	require.NoError(t, err)
-	require.Equal(t, 1, count, "there should be one volume linked")
+	require.Equal(t, 1, volumeCount(t, db, libraryID), "there should be one volume linked")
 
-	// Ensure a second call to link the same volume does nothing
+	// Ensure a second call to link the same volume does nothing.
 	err = db.LinkVolume(libraryID, volumeID)
 	require.NoError(t, err)
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
 	require.Equal(t, libraryID, lib, "there should be a library linked")
-	count, err = db.GetVolumeCount(libraryID)
-	require.NoError(t, err)
-	require.Equal(t, 1, count, "there should still be one volume linked")
+	require.Equal(t, 1, volumeCount(t, db, libraryID), "there should still be one volume linked")
 
 	// Ensure a second linked volume shows both.
 	secondVolumeID := "test-volume-id-two"
@@ -66,26 +74,22 @@ func TestDatabase(t *testing.T) {
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
 	require.Equal(t, libraryID, lib, "there should be a library linked")
-	count, err = db.GetVolumeCount(libraryID)
-	require.NoError(t, err)
-	require.Equal(t, 2, count, "there should be two volumes linked")
+	require.Equal(t, 2, volumeCount(t, db, libraryID), "there should be two volumes linked")
 
 	// Ensure an unlinked volume only has one volume linked.
-	err = db.UnlinkVolume(libraryID, secondVolumeID)
+	unlinked, _, err = db.UnlinkVolume(secondVolumeID)
 	require.NoError(t, err)
+	require.Equal(t, libraryID, unlinked, "unlink reports the library the volume used")
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
 	require.Equal(t, libraryID, lib, "there should be a library linked")
-	count, err = db.GetVolumeCount(libraryID)
-	require.NoError(t, err)
-	require.Equal(t, 1, count, "there should be one volume linked")
+	require.Equal(t, 1, volumeCount(t, db, libraryID), "there should be one volume linked")
 
 	// Ensure all unlinks completely zeros out the count.
-	err = db.UnlinkVolume(libraryID, volumeID)
+	unlinked, _, err = db.UnlinkVolume(volumeID)
 	require.NoError(t, err)
-	count, err = db.GetVolumeCount(libraryID)
-	require.NoError(t, err)
-	require.Equal(t, 0, count, "there should be no volumes linked")
+	require.Equal(t, libraryID, unlinked)
+	require.Equal(t, 0, volumeCount(t, db, libraryID), "there should be no volumes linked")
 	lib, err = db.GetLibraryForVolume(volumeID)
 	require.NoError(t, err)
 	require.Empty(t, lib, "there should be no libs linked")
@@ -99,36 +103,39 @@ func TestDatabaseLibraryMetadata(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	// A package with no cached library reports zero stats and an empty package name.
-	count, bytes := db.PackageCacheStats("unknown")
-	require.Equal(t, 0, count)
-	require.Equal(t, int64(0), bytes)
-
-	pkg, err := db.PackageForLibrary("unknown")
+	// An unknown library reports no record.
+	info, found, err := db.GetLibrary("unknown")
 	require.NoError(t, err)
-	require.Empty(t, pkg)
+	require.False(t, found)
+	require.Empty(t, info.Package)
+	require.Equal(t, int64(0), info.SizeBytes)
 
-	// Two versions of the same package aggregate together.
+	// Two versions of the same package aggregate together in the snapshot.
 	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 100))
 	require.NoError(t, db.AddLibrary("lib-id-2", "dd-lib-java-init", 200))
-	count, bytes = db.PackageCacheStats("dd-lib-java-init")
-	require.Equal(t, 2, count)
-	require.Equal(t, int64(300), bytes)
-
-	pkg, err = db.PackageForLibrary("lib-id-1")
+	snap, err := db.Snapshot()
 	require.NoError(t, err)
-	require.Equal(t, "dd-lib-java-init", pkg)
+	require.Equal(t, 2, snap.CachedCountByLibrary["dd-lib-java-init"])
+	require.Equal(t, int64(300), snap.CachedBytesByLibrary["dd-lib-java-init"])
+
+	info, found, err = db.GetLibrary("lib-id-1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "dd-lib-java-init", info.Package)
+	require.Equal(t, int64(100), info.SizeBytes)
 
 	// AddLibrary on the same library ID is idempotent: it overwrites the
 	// previous record without double-counting.
 	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 150))
-	count, bytes = db.PackageCacheStats("dd-lib-java-init")
-	require.Equal(t, 2, count)
-	require.Equal(t, int64(350), bytes)
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 2, snap.CachedCountByLibrary["dd-lib-java-init"])
+	require.Equal(t, int64(350), snap.CachedBytesByLibrary["dd-lib-java-init"])
 
 	// A different package is tracked independently.
 	require.NoError(t, db.AddLibrary("php-id", "dd-lib-php-init", 42))
-	snap := db.Snapshot()
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
 	require.Equal(t, 2, snap.CachedCountByLibrary["dd-lib-java-init"])
 	require.Equal(t, int64(350), snap.CachedBytesByLibrary["dd-lib-java-init"])
 	require.Equal(t, 1, snap.CachedCountByLibrary["dd-lib-php-init"])
@@ -136,15 +143,17 @@ func TestDatabaseLibraryMetadata(t *testing.T) {
 
 	// Removing one of two versions keeps the package present.
 	require.NoError(t, db.RemoveLibrary("lib-id-1"))
-	count, bytes = db.PackageCacheStats("dd-lib-java-init")
-	require.Equal(t, 1, count)
-	require.Equal(t, int64(200), bytes)
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 1, snap.CachedCountByLibrary["dd-lib-java-init"])
+	require.Equal(t, int64(200), snap.CachedBytesByLibrary["dd-lib-java-init"])
 
 	// Removing the last version drops the package entry from the aggregates.
 	require.NoError(t, db.RemoveLibrary("lib-id-2"))
-	count, bytes = db.PackageCacheStats("dd-lib-java-init")
-	require.Equal(t, 0, count)
-	require.Equal(t, int64(0), bytes)
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 0, snap.CachedCountByLibrary["dd-lib-java-init"])
+	require.Equal(t, int64(0), snap.CachedBytesByLibrary["dd-lib-java-init"])
 
 	// RemoveLibrary is a no-op on an unknown library.
 	require.NoError(t, db.RemoveLibrary("never-existed"))
@@ -164,9 +173,10 @@ func TestDatabaseMetadataPersistsAcrossRestart(t *testing.T) {
 	require.NoError(t, err)
 	defer db2.Close()
 
-	count, bytes := db2.PackageCacheStats("dd-lib-java-init")
-	require.Equal(t, 1, count)
-	require.Equal(t, int64(1024), bytes)
+	snap, err := db2.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 1, snap.CachedCountByLibrary["dd-lib-java-init"])
+	require.Equal(t, int64(1024), snap.CachedBytesByLibrary["dd-lib-java-init"])
 }
 
 func TestDatabaseValidatesBlankInputsForMetadata(t *testing.T) {
@@ -180,7 +190,11 @@ func TestDatabaseValidatesBlankInputsForMetadata(t *testing.T) {
 	require.Error(t, db.AddLibrary("", "pkg", 0))
 	require.Error(t, db.AddLibrary("lib", "", 0))
 	require.Error(t, db.RemoveLibrary(""))
-	_, err = db.PackageForLibrary("")
+	_, _, err = db.GetLibrary("")
+	require.Error(t, err)
+	_, _, err = db.UnlinkVolume("")
+	require.Error(t, err)
+	_, err = db.GetLibraryForVolume("")
 	require.Error(t, err)
 }
 
@@ -193,31 +207,48 @@ func TestDatabaseVolumeLinksAggregateByPackage(t *testing.T) {
 	defer db.Close()
 
 	// Aggregate is zero before any link is created.
-	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+	snap, err := db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 0, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 
-	// Without metadata the aggregate is not touched even after a link.
+	// Without metadata the aggregate is not touched even after a link
+	// (a library without a package label is excluded from the snapshot).
 	require.NoError(t, db.LinkVolume("lib-id-1", "vol-1"))
-	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 0, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 
-	// Once metadata is recorded, subsequent links update the aggregate.
+	// Once metadata is recorded, the aggregate reflects the links.
 	require.NoError(t, db.AddLibrary("lib-id-1", "dd-lib-java-init", 100))
 	require.NoError(t, db.AddLibrary("lib-id-2", "dd-lib-java-init", 200))
-	require.NoError(t, db.LinkVolume("lib-id-1", "vol-2"))
 	require.NoError(t, db.LinkVolume("lib-id-2", "vol-3"))
-	require.Equal(t, 2, db.VolumeLinkCount("dd-lib-java-init"))
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 
 	// Re-linking the same volume is a no-op for the aggregate.
-	require.NoError(t, db.LinkVolume("lib-id-1", "vol-2"))
-	require.Equal(t, 2, db.VolumeLinkCount("dd-lib-java-init"))
+	require.NoError(t, db.LinkVolume("lib-id-1", "vol-1"))
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 
-	// Unlinks decrement and eventually drop the package entry.
-	require.NoError(t, db.UnlinkVolume("lib-id-1", "vol-2"))
-	require.NoError(t, db.UnlinkVolume("lib-id-2", "vol-3"))
-	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+	// Unlinks decrement and eventually drop the package entry. The unlink
+	// also reports the package the volume used.
+	_, unlinkedPkg, err := db.UnlinkVolume("vol-1")
+	require.NoError(t, err)
+	require.Equal(t, "dd-lib-java-init", unlinkedPkg)
+	_, _, err = db.UnlinkVolume("vol-3")
+	require.NoError(t, err)
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 0, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 
 	// Unlinking an unknown volume is a no-op for the aggregate.
-	require.NoError(t, db.UnlinkVolume("lib-id-1", "never-existed"))
-	require.Equal(t, 0, db.VolumeLinkCount("dd-lib-java-init"))
+	_, _, err = db.UnlinkVolume("never-existed")
+	require.NoError(t, err)
+	snap, err = db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 0, snap.VolumeLinksByLibrary["dd-lib-java-init"])
 }
 
 func TestDatabaseVolumeLinksReloadedFromDisk(t *testing.T) {
@@ -235,6 +266,110 @@ func TestDatabaseVolumeLinksReloadedFromDisk(t *testing.T) {
 	require.NoError(t, err)
 	defer db2.Close()
 
-	snap := db2.Snapshot()
+	snap, err := db2.Snapshot()
+	require.NoError(t, err)
 	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
+}
+
+// TestDatabaseMigratesLegacySchema seeds a database with the legacy
+// nested-bucket schema (library-mappings/volume-mappings/library-metadata)
+// and verifies NewDatabase rewrites it into the flat volumes/libraries schema
+// without losing link or metadata information.
+func TestDatabaseMigratesLegacySchema(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	dbPath := filepath.Join(tsd.Path(t), librarymanager.DatabaseFileName)
+
+	// Build a legacy-shaped database by hand.
+	legacy, err := bbolt.Open(dbPath, 0600, nil)
+	require.NoError(t, err)
+	require.NoError(t, legacy.Update(func(tx *bbolt.Tx) error {
+		meta, err := tx.CreateBucketIfNotExists([]byte("library-metadata"))
+		if err != nil {
+			return err
+		}
+		encoded, err := json.Marshal(map[string]any{"package": "dd-lib-java-init", "size_bytes": 512})
+		if err != nil {
+			return err
+		}
+		if err := meta.Put([]byte("lib-id-1"), encoded); err != nil {
+			return err
+		}
+
+		mappings, err := tx.CreateBucketIfNotExists([]byte("library-mappings"))
+		if err != nil {
+			return err
+		}
+		libBkt, err := mappings.CreateBucketIfNotExists([]byte("lib-id-1"))
+		if err != nil {
+			return err
+		}
+		if err := libBkt.Put([]byte("vol-1"), []byte("{}")); err != nil {
+			return err
+		}
+		if err := libBkt.Put([]byte("vol-2"), []byte("{}")); err != nil {
+			return err
+		}
+
+		// A legacy library without metadata: it must still migrate its links.
+		orphanBkt, err := mappings.CreateBucketIfNotExists([]byte("lib-id-orphan"))
+		if err != nil {
+			return err
+		}
+		if err := orphanBkt.Put([]byte("vol-3"), []byte("{}")); err != nil {
+			return err
+		}
+
+		_, err = tx.CreateBucketIfNotExists([]byte("volume-mappings"))
+		return err
+	}))
+	require.NoError(t, legacy.Close())
+
+	// Reopen through NewDatabase, which runs the migration.
+	db, err := librarymanager.NewDatabase(tsd.Path(t))
+	require.NoError(t, err)
+
+	// Library metadata and the migrated volume count are preserved.
+	info, found, err := db.GetLibrary("lib-id-1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "dd-lib-java-init", info.Package)
+	require.Equal(t, int64(512), info.SizeBytes)
+	require.Equal(t, 2, info.VolumeCount)
+
+	// Volume -> library links survive the migration.
+	for _, vol := range []string{"vol-1", "vol-2"} {
+		lib, err := db.GetLibraryForVolume(vol)
+		require.NoError(t, err)
+		require.Equal(t, "lib-id-1", lib)
+	}
+
+	// The orphan library (no metadata) keeps its links and a count.
+	orphan, found, err := db.GetLibrary("lib-id-orphan")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Empty(t, orphan.Package)
+	require.Equal(t, 1, orphan.VolumeCount)
+
+	// The snapshot reflects only labelled libraries.
+	snap, err := db.Snapshot()
+	require.NoError(t, err)
+	require.Equal(t, 1, snap.CachedCountByLibrary["dd-lib-java-init"])
+	require.Equal(t, int64(512), snap.CachedBytesByLibrary["dd-lib-java-init"])
+	require.Equal(t, 2, snap.VolumeLinksByLibrary["dd-lib-java-init"])
+
+	// The legacy buckets are gone after migration.
+	require.NoError(t, db.Close())
+	check, err := bbolt.Open(dbPath, 0600, nil)
+	require.NoError(t, err)
+	defer check.Close()
+	require.NoError(t, check.View(func(tx *bbolt.Tx) error {
+		require.Nil(t, tx.Bucket([]byte("library-mappings")))
+		require.Nil(t, tx.Bucket([]byte("volume-mappings")))
+		require.Nil(t, tx.Bucket([]byte("library-metadata")))
+		require.NotNil(t, tx.Bucket([]byte("volumes")))
+		require.NotNil(t, tx.Bucket([]byte("libraries")))
+		return nil
+	}))
 }

--- a/pkg/librarymanager/events_test.go
+++ b/pkg/librarymanager/events_test.go
@@ -187,6 +187,64 @@ func TestLibraryManagerEmitsLifecycleEvents(t *testing.T) {
 		"the library should be removed once unused")
 }
 
+// TestLibraryManagerReusesLibraryForRepublishedVolume verifies that
+// re-publishing an already-linked volume reuses the library it was first linked
+// to, without re-resolving the image. Even when the (mutable) tag no longer
+// resolves, the volume keeps its original library: the call succeeds with a
+// cache hit and records no extra download, cache, or link.
+func TestLibraryManagerReusesLibraryForRepublishedVolume(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	localRegistry.AddImage(t, "testdata/image.tar", "test-image", "latest")
+
+	d := librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+	ctx := context.Background()
+
+	rec := &recordingListener{}
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(d),
+		librarymanager.WithEventListener(rec),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+	rec.drain() // discard the startup snapshot
+
+	lib, err := librarymanager.NewLibrary("test-image", localRegistry.Registry(t), "latest", false)
+	require.NoError(t, err)
+
+	// First publish: cache miss -> download and link.
+	firstPath, err := lm.GetLibraryForVolume(ctx, "vol-1", lib)
+	require.NoError(t, err)
+	first := rec.drain()
+	require.Equal(t, libraryevents.ResolutionDownloaded, singleEvent(t, first, "resolved").result)
+	require.Equal(t, 1, singleEvent(t, first, "linked").links)
+
+	// Re-publish the same volume with a tag that no longer resolves (pull
+	// forced, so a resolution attempt would fail). The volume is already
+	// linked, so the manager must reuse its library without touching the
+	// registry: no error, no download, no new link.
+	stale, err := librarymanager.NewLibrary("test-image", localRegistry.Registry(t), "does-not-exist", true)
+	require.NoError(t, err)
+	reusedPath, err := lm.GetLibraryForVolume(ctx, "vol-1", stale)
+	require.NoError(t, err)
+	require.Equal(t, firstPath, reusedPath, "a re-published volume must reuse its original library path")
+
+	second := rec.drain()
+	require.Equal(t, libraryevents.ResolutionCacheHit, singleEvent(t, second, "resolved").result)
+	require.Empty(t, eventsOfKind(second, "download"), "reusing a linked volume must not download")
+	require.Empty(t, eventsOfKind(second, "cached"), "reusing a linked volume must not re-cache")
+	require.Empty(t, eventsOfKind(second, "linked"), "reusing a linked volume must not add a link")
+
+	// The library was referenced exactly once, so removing the volume evicts it.
+	require.NoError(t, lm.RemoveVolume(ctx, "vol-1"))
+	afterRemove := rec.drain()
+	require.Equal(t, 0, singleEvent(t, afterRemove, "unlinked").links)
+	require.Equal(t, libraryevents.CleanupSuccess, singleEvent(t, afterRemove, "cleanup").status)
+}
+
 // TestLibraryManagerEmitsFailedResolution checks that a resolution failure
 // (here, an image that cannot be resolved) surfaces as a "failed" resolution
 // and does not link a volume.

--- a/pkg/librarymanager/events_test.go
+++ b/pkg/librarymanager/events_test.go
@@ -1,0 +1,346 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package librarymanager_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Datadog/datadog-csi-driver/pkg/libraryevents"
+	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
+	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+// recordedEvent is a flattened record of a single Listener call. Only the
+// fields relevant to the invoked method are populated.
+type recordedEvent struct {
+	kind     string
+	library  string
+	result   libraryevents.ResolutionResult
+	status   libraryevents.CleanupStatus
+	strategy string
+	registry string
+	duration time.Duration
+	count    int
+	bytes    int64
+	links    int
+	snapshot libraryevents.Snapshot
+}
+
+// recordingListener captures every Listener call so tests can assert which
+// events the LibraryManager emits, in which order, and with which arguments.
+type recordingListener struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+// compile-time check that the test double satisfies the interface.
+var _ libraryevents.Listener = (*recordingListener)(nil)
+
+func (r *recordingListener) record(e recordedEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, e)
+}
+
+// drain returns every event captured since the last drain and clears the
+// buffer, so each step of a test can assert only the events it triggered.
+func (r *recordingListener) drain() []recordedEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := r.events
+	r.events = nil
+	return out
+}
+
+func (r *recordingListener) OnLibraryResolved(library string, result libraryevents.ResolutionResult) {
+	r.record(recordedEvent{kind: "resolved", library: library, result: result})
+}
+
+func (r *recordingListener) OnLibraryDownload(library, registry string, d time.Duration) {
+	r.record(recordedEvent{kind: "download", library: library, registry: registry, duration: d})
+}
+
+func (r *recordingListener) OnLibraryCleanup(library string, status libraryevents.CleanupStatus, strategy string) {
+	r.record(recordedEvent{kind: "cleanup", library: library, status: status, strategy: strategy})
+}
+
+func (r *recordingListener) OnLibraryCached(library string, count int, bytes int64) {
+	r.record(recordedEvent{kind: "cached", library: library, count: count, bytes: bytes})
+}
+
+func (r *recordingListener) OnLibraryEvicted(library string, count int, bytes int64) {
+	r.record(recordedEvent{kind: "evicted", library: library, count: count, bytes: bytes})
+}
+
+func (r *recordingListener) OnVolumeLinked(library string, links int) {
+	r.record(recordedEvent{kind: "linked", library: library, links: links})
+}
+
+func (r *recordingListener) OnVolumeUnlinked(library string, links int) {
+	r.record(recordedEvent{kind: "unlinked", library: library, links: links})
+}
+
+func (r *recordingListener) OnSnapshot(s libraryevents.Snapshot) {
+	r.record(recordedEvent{kind: "snapshot", snapshot: s})
+}
+
+func eventsOfKind(events []recordedEvent, kind string) []recordedEvent {
+	var out []recordedEvent
+	for _, e := range events {
+		if e.kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// singleEvent asserts exactly one event of the given kind was recorded and
+// returns it.
+func singleEvent(t *testing.T, events []recordedEvent, kind string) recordedEvent {
+	t.Helper()
+	matched := eventsOfKind(events, kind)
+	require.Lenf(t, matched, 1, "expected exactly one %q event, got %d in %+v", kind, len(matched), events)
+	return matched[0]
+}
+
+// TestLibraryManagerEmitsLifecycleEvents walks a full download -> share ->
+// release lifecycle for two volumes on the same library and asserts the
+// listener sees the right events at each step. It also covers the
+// "skipped_in_use" cleanup path (the library must stay on disk while a second
+// volume still uses it).
+func TestLibraryManagerEmitsLifecycleEvents(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	localRegistry.AddImage(t, "testdata/image.tar", "test-image", "latest")
+
+	d := librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+	basePath := tsd.Path(t)
+	ctx := context.Background()
+
+	rec := &recordingListener{}
+	lm, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(d),
+		librarymanager.WithEventListener(rec),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+
+	// Construction seeds an (empty) snapshot.
+	require.Empty(t, singleEvent(t, rec.drain(), "snapshot").snapshot.CachedCountByLibrary)
+
+	lib, err := librarymanager.NewLibrary("test-image", localRegistry.Registry(t), "latest", false)
+	require.NoError(t, err)
+
+	// First volume: cache miss -> download.
+	_, err = lm.GetLibraryForVolume(ctx, "vol-1", lib)
+	require.NoError(t, err)
+	first := rec.drain()
+	require.Equal(t, libraryevents.ResolutionDownloaded, singleEvent(t, first, "resolved").result)
+	require.Equal(t, "test-image", singleEvent(t, first, "download").library)
+	cached := singleEvent(t, first, "cached")
+	require.Equal(t, 1, cached.count)
+	require.Greater(t, cached.bytes, int64(0))
+	require.Equal(t, 1, singleEvent(t, first, "linked").links)
+
+	// Second volume, same library: cache hit, no new download/cached.
+	_, err = lm.GetLibraryForVolume(ctx, "vol-2", lib)
+	require.NoError(t, err)
+	second := rec.drain()
+	require.Equal(t, libraryevents.ResolutionCacheHit, singleEvent(t, second, "resolved").result)
+	require.Equal(t, 2, singleEvent(t, second, "linked").links)
+	require.Empty(t, eventsOfKind(second, "download"), "a cache hit must not download")
+	require.Empty(t, eventsOfKind(second, "cached"), "a cache hit must not re-cache")
+
+	// Remove the first of two volumes: unlink, cleanup skipped (still in use),
+	// the library must remain on disk.
+	require.NoError(t, lm.RemoveVolume(ctx, "vol-1"))
+	afterFirst := rec.drain()
+	require.Equal(t, 1, singleEvent(t, afterFirst, "unlinked").links)
+	require.Equal(t, libraryevents.CleanupSkippedInUse, singleEvent(t, afterFirst, "cleanup").status)
+	require.Empty(t, eventsOfKind(afterFirst, "evicted"), "a library still in use must not be evicted")
+	require.NotEmpty(t, testutil.ListFiles(t, filepath.Join(basePath, librarymanager.StoreDirectory)),
+		"the library should remain on disk while a volume still uses it")
+
+	// Remove the last volume: unlink, eviction, cleanup success, library gone.
+	require.NoError(t, lm.RemoveVolume(ctx, "vol-2"))
+	afterLast := rec.drain()
+	require.Equal(t, 0, singleEvent(t, afterLast, "unlinked").links)
+	evicted := singleEvent(t, afterLast, "evicted")
+	require.Equal(t, 0, evicted.count)
+	require.Equal(t, int64(0), evicted.bytes)
+	require.Equal(t, libraryevents.CleanupSuccess, singleEvent(t, afterLast, "cleanup").status)
+	require.Empty(t, testutil.ListFiles(t, filepath.Join(basePath, librarymanager.StoreDirectory)),
+		"the library should be removed once unused")
+}
+
+// TestLibraryManagerEmitsFailedResolution checks that a resolution failure
+// (here, an image that cannot be resolved) surfaces as a "failed" resolution
+// and does not link a volume.
+func TestLibraryManagerEmitsFailedResolution(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	// No image is added, so the digest lookup fails.
+
+	d := librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	rec := &recordingListener{}
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(d),
+		librarymanager.WithEventListener(rec),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+	rec.drain() // discard the startup snapshot
+
+	lib, err := librarymanager.NewLibrary("missing-image", localRegistry.Registry(t), "v0.0.0", true)
+	require.NoError(t, err)
+
+	_, err = lm.GetLibraryForVolume(context.Background(), "vol-x", lib)
+	require.Error(t, err)
+	events := rec.drain()
+	require.Equal(t, libraryevents.ResolutionFailed, singleEvent(t, events, "resolved").result)
+	require.Empty(t, eventsOfKind(events, "linked"), "a failed resolution must not link a volume")
+	require.Empty(t, eventsOfKind(events, "cached"), "a failed resolution must not cache a library")
+}
+
+// TestLibraryManagerSeedsSnapshotOnRestart verifies that a freshly built
+// LibraryManager seeds its listener from the persisted state, so gauges are
+// correct immediately after a driver restart.
+func TestLibraryManagerSeedsSnapshotOnRestart(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	localRegistry.AddImage(t, "testdata/image.tar", "test-image", "latest")
+	d := librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))
+
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+	basePath := tsd.Path(t)
+	ctx := context.Background()
+
+	// First run: download and link a volume, then stop.
+	lm, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(d),
+	)
+	require.NoError(t, err)
+	lib, err := librarymanager.NewLibrary("test-image", localRegistry.Registry(t), "latest", false)
+	require.NoError(t, err)
+	_, err = lm.GetLibraryForVolume(ctx, "vol-1", lib)
+	require.NoError(t, err)
+	require.NoError(t, lm.Stop())
+
+	// Second run: a fresh listener must be seeded from the persisted state.
+	rec := &recordingListener{}
+	lm2, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(d),
+		librarymanager.WithEventListener(rec),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm2.Stop()) }()
+
+	snap := singleEvent(t, rec.drain(), "snapshot").snapshot
+	require.Equal(t, 1, snap.CachedCountByLibrary["test-image"])
+	require.Equal(t, 1, snap.VolumeLinksByLibrary["test-image"])
+	require.Greater(t, snap.CachedBytesByLibrary["test-image"], int64(0))
+}
+
+// TestLibraryManagerRemoveUnknownVolumeIsNoop checks that removing a volume
+// that was never linked is a no-op that emits no events.
+func TestLibraryManagerRemoveUnknownVolumeIsNoop(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	rec := &recordingListener{}
+	lm, err := librarymanager.NewLibraryManager(tsd.Path(t),
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithEventListener(rec),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+	rec.drain() // discard the startup snapshot
+
+	require.NoError(t, lm.RemoveVolume(context.Background(), "never-linked"))
+	require.Empty(t, rec.drain(), "removing an untracked volume must emit no events")
+}
+
+// TestLibraryManagerCleanupEmitsEmptyLabelForMigratedLibrary covers a library
+// migrated from the legacy schema without per-library metadata: its cleanup
+// must still fire (with an empty package label) and must not publish gauge
+// events, since it was never tracked as a labelled series.
+func TestLibraryManagerCleanupEmitsEmptyLabelForMigratedLibrary(t *testing.T) {
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+	basePath := tsd.Path(t)
+
+	const (
+		libraryID = "legacy-lib-id"
+		volumeID  = "legacy-vol-id"
+	)
+
+	// Seed a legacy-schema DB (a link without metadata) plus the matching
+	// store directory on disk.
+	dbDir := filepath.Join(basePath, librarymanager.DatabaseDirectory)
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	seedLegacyLink(t, filepath.Join(dbDir, librarymanager.DatabaseFileName), libraryID, volumeID)
+
+	storeLibDir := filepath.Join(basePath, librarymanager.StoreDirectory, libraryID)
+	require.NoError(t, os.MkdirAll(storeLibDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(storeLibDir, "library.txt"), []byte("x"), 0o644))
+
+	rec := &recordingListener{}
+	lm, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithEventListener(rec),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+	rec.drain() // a migrated library has no package, so the seed snapshot is empty
+
+	require.NoError(t, lm.RemoveVolume(context.Background(), volumeID))
+	events := rec.drain()
+
+	cleanup := singleEvent(t, events, "cleanup")
+	require.Equal(t, libraryevents.CleanupSuccess, cleanup.status)
+	require.Empty(t, cleanup.library, "a migrated library without metadata is cleaned up with an empty label")
+	require.Empty(t, eventsOfKind(events, "evicted"), "no eviction gauge for a library without a package label")
+	require.Empty(t, eventsOfKind(events, "unlinked"), "no unlink gauge for a library without a package label")
+	require.Empty(t, testutil.ListFiles(t, filepath.Join(basePath, librarymanager.StoreDirectory)))
+}
+
+// seedLegacyLink writes a single volume->library link into a legacy-schema
+// bbolt database (the nested library-mappings bucket).
+func seedLegacyLink(t *testing.T, dbPath, libraryID, volumeID string) {
+	t.Helper()
+	db, err := bbolt.Open(dbPath, 0600, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		mappings, err := tx.CreateBucketIfNotExists([]byte("library-mappings"))
+		if err != nil {
+			return err
+		}
+		libBkt, err := mappings.CreateBucketIfNotExists([]byte(libraryID))
+		if err != nil {
+			return err
+		}
+		return libBkt.Put([]byte(volumeID), []byte("{}"))
+	}))
+	require.NoError(t, db.Close())
+}

--- a/pkg/librarymanager/events_test.go
+++ b/pkg/librarymanager/events_test.go
@@ -245,6 +245,71 @@ func TestLibraryManagerReusesLibraryForRepublishedVolume(t *testing.T) {
 	require.Equal(t, libraryevents.CleanupSuccess, singleEvent(t, afterRemove, "cleanup").status)
 }
 
+// TestLibraryManagerRedownloadsLinkedLibraryMissingFromStore covers the
+// recovery path: a volume stays linked in the DB, but its library directory
+// disappears from the store (host disk cleanup or corruption while the DB file
+// survives). Re-publishing the volume must restore the exact same content by
+// digest without re-resolving the tag, re-recording metadata, or adding a link.
+func TestLibraryManagerRedownloadsLinkedLibraryMissingFromStore(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	localRegistry.AddImage(t, "testdata/image.tar", "test-image", "latest")
+
+	d := librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+	basePath := tsd.Path(t)
+	ctx := context.Background()
+
+	rec := &recordingListener{}
+	lm, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(afero.Afero{Fs: afero.NewOsFs()}),
+		librarymanager.WithDownloader(d),
+		librarymanager.WithEventListener(rec),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lm.Stop()) }()
+	rec.drain() // discard the startup snapshot
+
+	lib, err := librarymanager.NewLibrary("test-image", localRegistry.Registry(t), "latest", false)
+	require.NoError(t, err)
+
+	// First publish: cache miss -> download and link.
+	firstPath, err := lm.GetLibraryForVolume(ctx, "vol-1", lib)
+	require.NoError(t, err)
+	require.Equal(t, libraryevents.ResolutionDownloaded, singleEvent(t, rec.drain(), "resolved").result)
+
+	// Wipe the library directory from the store while keeping the store root
+	// and the DB link intact, simulating external corruption.
+	storeDir := filepath.Join(basePath, librarymanager.StoreDirectory)
+	entries, err := os.ReadDir(storeDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "the store should hold the downloaded library")
+	for _, e := range entries {
+		require.NoError(t, os.RemoveAll(filepath.Join(storeDir, e.Name())))
+	}
+
+	// Re-publish the same volume: the link still points at the missing library,
+	// so the manager must redownload the pinned digest and restore the store.
+	restoredPath, err := lm.GetLibraryForVolume(ctx, "vol-1", lib)
+	require.NoError(t, err)
+	require.Equal(t, firstPath, restoredPath, "the restored library must keep its original store path")
+
+	recovery := rec.drain()
+	require.Equal(t, libraryevents.ResolutionDownloaded, singleEvent(t, recovery, "resolved").result)
+	require.Equal(t, "test-image", singleEvent(t, recovery, "download").library,
+		"restoring a missing store entry must redownload the library")
+	require.Empty(t, eventsOfKind(recovery, "cached"), "recovery must not re-record library metadata")
+	require.Empty(t, eventsOfKind(recovery, "linked"), "recovery must not add a link to an already-linked volume")
+	require.NotEmpty(t, testutil.ListFiles(t, storeDir), "the library should be back on disk after recovery")
+
+	// The link count never drifted, so removing the volume evicts the library.
+	require.NoError(t, lm.RemoveVolume(ctx, "vol-1"))
+	afterRemove := rec.drain()
+	require.Equal(t, 0, singleEvent(t, afterRemove, "unlinked").links)
+	require.Equal(t, libraryevents.CleanupSuccess, singleEvent(t, afterRemove, "cleanup").status)
+}
+
 // TestLibraryManagerEmitsFailedResolution checks that a resolution failure
 // (here, an image that cannot be resolved) surfaces as a "failed" resolution
 // and does not link a volume.

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -278,8 +278,16 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 // keeping the listener invocation paired with the LinkVolume call avoids the
 // easy mistake of forgetting one of the two.
 func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string) error {
-	if err := lm.db.LinkVolume(libraryID, volumeID); err != nil {
+	previousLibraryID, err := lm.db.LinkVolume(libraryID, volumeID)
+	if err != nil {
 		return err
+	}
+	// If the volume was previously linked to a different library, the transfer
+	// may have dropped that library's volume count to zero. RemoveVolume is the
+	// only other place that schedules cleanup, so do it here too; otherwise the
+	// displaced library would linger on disk until the next restart.
+	if previousLibraryID != "" {
+		lm.cleanupStrategy.ScheduleCleanup(previousLibraryID, lm.tryCleanupLibrary)
 	}
 	_, _, volumeLinks := lm.packageStats(library)
 	lm.listener.OnVolumeLinked(library, volumeLinks)

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -146,9 +146,24 @@ func NewLibraryManager(basePath string, opts ...LibraryManagerOption) (*LibraryM
 	// Seed listener gauges from the persisted state, so dashboards reflect
 	// reality immediately after a driver restart instead of waiting for the
 	// first event.
-	lm.listener.OnSnapshot(lm.db.Snapshot())
+	if snap, err := lm.db.Snapshot(); err != nil {
+		log.Error("could not seed library metrics from persisted state", "error", err)
+	} else {
+		lm.listener.OnSnapshot(snap)
+	}
 
 	return lm, nil
+}
+
+// packageStats reads the per-package aggregates used to label gauge events.
+// Metrics are best-effort: a read error is logged and reported as zeroed
+// stats so a metrics hiccup never fails the mount/unmount that triggered it.
+func (lm *LibraryManager) packageStats(library string) (cachedCount int, cachedBytes int64, volumeLinks int) {
+	cachedCount, cachedBytes, volumeLinks, err := lm.db.PackageStats(library)
+	if err != nil {
+		log.Error("could not read library stats for metrics", "library", library, "error", err)
+	}
+	return cachedCount, cachedBytes, volumeLinks
 }
 
 // Stop ensures all dependencies are stopped correctly.
@@ -238,14 +253,14 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	}
 	log.Info("Library downloaded and stored", "image", lib.Image(), "path", storePath)
 
-	// Record the library in the metadata bucket and notify the listener.
-	// AddLibrary is the canonical writer for the per-library metadata; it
-	// must be called before LinkVolume so the volume-links aggregate has
-	// the right package name to associate the link with.
+	// Record the library so its package name and on-disk size are persisted.
+	// AddLibrary is the canonical writer for the per-library record; it must
+	// run before LinkVolume so the library record exists when the volume
+	// count is incremented.
 	if err := lm.db.AddLibrary(libraryID, lib.Name(), sizeBytes); err != nil {
 		return "", fmt.Errorf("could not record library metadata: %w", err)
 	}
-	count, totalBytes := lm.db.PackageCacheStats(lib.Name())
+	count, totalBytes, _ := lm.packageStats(lib.Name())
 	lm.listener.OnLibraryCached(lib.Name(), count, totalBytes)
 
 	if err := lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
@@ -256,51 +271,42 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	return storePath, nil
 }
 
-// linkVolume persists the library/volume link and notifies the listener
-// with the resulting per-library count. It is intentionally a tiny helper:
-// keeping the listener invocation paired with the LinkVolume call avoids
-// the easy mistake of forgetting one of the two.
+// linkVolume persists the library/volume link and notifies the listener with
+// the resulting per-library volume count. It is intentionally a tiny helper:
+// keeping the listener invocation paired with the LinkVolume call avoids the
+// easy mistake of forgetting one of the two.
 func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string) error {
 	if err := lm.db.LinkVolume(libraryID, volumeID); err != nil {
 		return err
 	}
-	lm.listener.OnVolumeLinked(library, lm.db.VolumeLinkCount(library))
+	_, _, volumeLinks := lm.packageStats(library)
+	lm.listener.OnVolumeLinked(library, volumeLinks)
 	return nil
 }
 
 // RemoveVolume removes the link between the LibraryID and the VolumeID in the database.
 // If there are no more uses of the library, it is also removed from disk.
 // Calling RemoveVolume for a volume that was never linked is a no-op.
-func (lm *LibraryManager) RemoveVolume(ctx context.Context, volumeID string) error {
-	// Look up the linked library.
-	libraryID, err := lm.db.GetLibraryForVolume(volumeID)
+func (lm *LibraryManager) RemoveVolume(_ context.Context, volumeID string) error {
+	// Unlink the volume. UnlinkVolume returns both the library it was linked
+	// to and that library's package name (read off the persisted record while
+	// decrementing the count), so we get the gauge label without a separate
+	// lookup before the link is wiped.
+	// Note: No lock needed here because:
+	// - UnlinkVolume is atomic (database has its own locking)
+	// - tryCleanupLibrary acquires the lock before checking and removing
+	libraryID, library, err := lm.db.UnlinkVolume(volumeID)
 	if err != nil {
-		return fmt.Errorf("could not determine which library was linked for volume %s: %w", volumeID, err)
+		return fmt.Errorf("could not unlink volume ID %s: %w", volumeID, err)
 	}
 	if libraryID == "" {
 		// Nothing to do: the volume was never linked or has already been
 		// removed. We return nil here to keep idempotency.
 		return nil
 	}
-
-	// Resolve the library name now, before the link (and possibly the
-	// metadata) is wiped, so we can notify the listener with the right
-	// gauge label.
-	library, err := lm.db.PackageForLibrary(libraryID)
-	if err != nil {
-		return fmt.Errorf("could not resolve library for ID %s: %w", libraryID, err)
-	}
-
-	// Unlink the volume from the database.
-	// Note: No lock needed here because:
-	// - UnlinkVolume is atomic (database has its own locking)
-	// - tryCleanupLibrary acquires the lock before checking and removing
-	err = lm.db.UnlinkVolume(libraryID, volumeID)
-	if err != nil {
-		return fmt.Errorf("could not unlink volume ID %s: %w", volumeID, err)
-	}
 	if library != "" {
-		lm.listener.OnVolumeUnlinked(library, lm.db.VolumeLinkCount(library))
+		_, _, volumeLinks := lm.packageStats(library)
+		lm.listener.OnVolumeUnlinked(library, volumeLinks)
 	}
 
 	// Schedule cleanup - tryCleanupLibrary will check if the library is still in use
@@ -318,42 +324,36 @@ func (lm *LibraryManager) tryCleanupLibrary(libraryID string) error {
 	lm.locker.Lock(libraryID)
 	defer lm.locker.Unlock(libraryID)
 
-	// Look up the library name up-front so every cleanup event carries the
-	// right label. Older entries on disk that predate the metadata bucket
-	// resolve to an empty string; the cached gauges are skipped for them
-	// (we never tracked them in the first place) but the cleanup counter
-	// is still incremented.
-	library, err := lm.db.PackageForLibrary(libraryID)
+	// Read the library record once: it carries both the package label every
+	// cleanup event needs and the live volume count. Legacy entries that
+	// predate per-library metadata resolve to an empty package; the gauges
+	// were never published for them, but the cleanup counter still fires.
+	info, _, err := lm.db.GetLibrary(libraryID)
 	if err != nil {
 		lm.listener.OnLibraryCleanup("", libraryevents.CleanupFailed, strategy)
 		return fmt.Errorf("could not get library for ID %s: %w", libraryID, err)
 	}
 
 	// Check if the library is still in use
-	count, err := lm.db.GetVolumeCount(libraryID)
-	if err != nil {
-		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupFailed, strategy)
-		return fmt.Errorf("could not get linked library count: %w", err)
-	}
-	if count > 0 {
-		log.Info("Library still in use, skipping cleanup", "library_id", libraryID, "count", count)
-		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupSkippedInUse, strategy)
+	if info.VolumeCount > 0 {
+		log.Info("Library still in use, skipping cleanup", "library_id", libraryID, "count", info.VolumeCount)
+		lm.listener.OnLibraryCleanup(info.Package, libraryevents.CleanupSkippedInUse, strategy)
 		return nil
 	}
 	log.Info("Removing library from disk", "library_id", libraryID)
 
 	if err := lm.store.Remove(libraryID); err != nil {
-		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupFailed, strategy)
+		lm.listener.OnLibraryCleanup(info.Package, libraryevents.CleanupFailed, strategy)
 		return err
 	}
 	if err := lm.db.RemoveLibrary(libraryID); err != nil {
-		lm.listener.OnLibraryCleanup(library, libraryevents.CleanupFailed, strategy)
+		lm.listener.OnLibraryCleanup(info.Package, libraryevents.CleanupFailed, strategy)
 		return fmt.Errorf("could not remove library metadata for %s: %w", libraryID, err)
 	}
-	if library != "" {
-		newCount, newBytes := lm.db.PackageCacheStats(library)
-		lm.listener.OnLibraryEvicted(library, newCount, newBytes)
+	if info.Package != "" {
+		newCount, newBytes, _ := lm.packageStats(info.Package)
+		lm.listener.OnLibraryEvicted(info.Package, newCount, newBytes)
 	}
-	lm.listener.OnLibraryCleanup(library, libraryevents.CleanupSuccess, strategy)
+	lm.listener.OnLibraryCleanup(info.Package, libraryevents.CleanupSuccess, strategy)
 	return nil
 }

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -359,13 +359,20 @@ func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string, fromCa
 // If there are no more uses of the library, it is also removed from disk.
 // Calling RemoveVolume for a volume that was never linked is a no-op.
 func (lm *LibraryManager) RemoveVolume(_ context.Context, volumeID string) error {
+	// Serialize against GetLibraryForVolume for the same volume: both take the
+	// per-volume lock so an unpublish can never wipe the link (and trigger the
+	// library's cleanup) in the middle of a concurrent publish that has already
+	// resolved the volume's library but not yet finished reusing it. Different
+	// volumes still proceed concurrently.
+	lm.locker.Lock(volumeLockKey(volumeID))
+	defer lm.locker.Unlock(volumeLockKey(volumeID))
+
 	// Unlink the volume. UnlinkVolume returns both the library it was linked
 	// to and that library's package name (read off the persisted record while
 	// decrementing the count), so we get the gauge label without a separate
-	// lookup before the link is wiped.
-	// Note: No lock needed here because:
-	// - UnlinkVolume is atomic (database has its own locking)
-	// - tryCleanupLibrary acquires the lock before checking and removing
+	// lookup before the link is wiped. tryCleanupLibrary acquires the library
+	// lock before checking and removing (ordering is always volume -> library,
+	// so the two locks never deadlock).
 	libraryID, library, err := lm.db.UnlinkVolume(volumeID)
 	if err != nil {
 		return fmt.Errorf("could not unlink volume ID %s: %w", volumeID, err)

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -216,6 +216,18 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	// we resolve, so we can defer LinkVolume to after we have confirmed
 	// the library is on disk and recorded in the metadata bucket.
 	lm.locker.Lock(libraryID)
+	// If linking this volume transfers it away from another library, that
+	// displaced library may now be unused. Schedule its cleanup only after the
+	// target lock above is released: registering this defer before the Unlock
+	// defer makes it run afterwards (defers are LIFO), so an
+	// ImmediateCleanupStrategy never locks the displaced library while we still
+	// hold this one — which would deadlock two opposite re-publishes.
+	var displacedLibraryID string
+	defer func() {
+		if displacedLibraryID != "" {
+			lm.cleanupStrategy.ScheduleCleanup(displacedLibraryID, lm.tryCleanupLibrary)
+		}
+	}()
 	defer lm.locker.Unlock(libraryID)
 
 	// If the library already exists, return it.
@@ -225,7 +237,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	}
 	if path != "" {
 		log.Info("Library already cached", "image", lib.Image(), "path", path)
-		if err := lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
+		if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
 			return "", err
 		}
 		result = libraryevents.ResolutionCacheHit
@@ -265,7 +277,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	count, totalBytes, _ := lm.packageStats(lib.Name())
 	lm.listener.OnLibraryCached(lib.Name(), count, totalBytes)
 
-	if err := lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
+	if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
 		return "", err
 	}
 
@@ -277,21 +289,35 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 // the resulting per-library volume count. It is intentionally a tiny helper:
 // keeping the listener invocation paired with the LinkVolume call avoids the
 // easy mistake of forgetting one of the two.
-func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string) error {
-	previousLibraryID, err := lm.db.LinkVolume(libraryID, volumeID)
+//
+// When the volume was already tracked under a different library (a re-publish
+// without an intervening unlink), LinkVolume transfers the link and decrements
+// the previous library. In that case linkVolume also emits the unlink gauge for
+// the displaced library — while its record still exists — and returns its ID so
+// the caller can schedule its cleanup once the current library lock is
+// released. Cleanup is deliberately not scheduled here: an
+// ImmediateCleanupStrategy would run it synchronously and lock the displaced
+// library while the caller still holds the target library lock, which could
+// deadlock two volumes re-published in opposite directions.
+func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string) (displacedLibraryID string, err error) {
+	displacedLibraryID, err = lm.db.LinkVolume(libraryID, volumeID)
 	if err != nil {
-		return err
+		return "", err
 	}
-	// If the volume was previously linked to a different library, the transfer
-	// may have dropped that library's volume count to zero. RemoveVolume is the
-	// only other place that schedules cleanup, so do it here too; otherwise the
-	// displaced library would linger on disk until the next restart.
-	if previousLibraryID != "" {
-		lm.cleanupStrategy.ScheduleCleanup(previousLibraryID, lm.tryCleanupLibrary)
-	}
+
 	_, _, volumeLinks := lm.packageStats(library)
 	lm.listener.OnVolumeLinked(library, volumeLinks)
-	return nil
+
+	// The transfer decremented the displaced library's persisted count, so
+	// refresh its gauge now (before any cleanup can remove the record);
+	// otherwise library_volume_links would stay stale until the next restart.
+	if displacedLibraryID != "" {
+		if info, found, gerr := lm.db.GetLibrary(displacedLibraryID); gerr == nil && found && info.Package != "" {
+			_, _, displacedLinks := lm.packageStats(info.Package)
+			lm.listener.OnVolumeUnlinked(info.Package, displacedLinks)
+		}
+	}
+	return displacedLibraryID, nil
 }
 
 // RemoveVolume removes the link between the LibraryID and the VolumeID in the database.

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -237,7 +237,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	}
 	if path != "" {
 		log.Info("Library already cached", "image", lib.Image(), "path", path)
-		if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
+		if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name(), true); err != nil {
 			return "", err
 		}
 		result = libraryevents.ResolutionCacheHit
@@ -277,7 +277,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	count, totalBytes, _ := lm.packageStats(lib.Name())
 	lm.listener.OnLibraryCached(lib.Name(), count, totalBytes)
 
-	if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name()); err != nil {
+	if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name(), false); err != nil {
 		return "", err
 	}
 
@@ -299,8 +299,8 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 // ImmediateCleanupStrategy would run it synchronously and lock the displaced
 // library while the caller still holds the target library lock, which could
 // deadlock two volumes re-published in opposite directions.
-func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string) (displacedLibraryID string, err error) {
-	displacedLibraryID, err = lm.db.LinkVolume(libraryID, volumeID)
+func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string, fromCache bool) (displacedLibraryID string, err error) {
+	displacedLibraryID, err = lm.db.LinkVolume(libraryID, volumeID, fromCache)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -206,28 +206,42 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return "", fmt.Errorf("library cannot be nil")
 	}
 
+	// A volume is published once and keeps the same library for its whole
+	// lifetime. If it is already linked, resolve it from its existing record
+	// instead of re-resolving the image: this makes NodePublishVolume
+	// idempotent and stops a volume from ever pointing at two libraries (e.g. a
+	// mutable tag whose digest changed between a failed publish and a retry).
+	existingLibraryID, err := lm.db.GetLibraryForVolume(volumeID)
+	if err != nil {
+		return "", err
+	}
+	if existingLibraryID != "" {
+		lm.locker.Lock(existingLibraryID)
+		defer lm.locker.Unlock(existingLibraryID)
+
+		// An active link guarantees the library is still on disk: cleanup only
+		// removes a library once its volume count reaches zero. Any error here
+		// (including ErrItemNotFound) is therefore unexpected and surfaces as a
+		// publish failure rather than being treated as a cache miss.
+		path, err := lm.store.Get(existingLibraryID)
+		if err != nil {
+			return "", err
+		}
+		log.Info("Reusing library already linked to volume", "image", lib.Image(), "path", path)
+		result = libraryevents.ResolutionCacheHit
+		return path, nil
+	}
+
 	// Fetch the library ID based on the image digest.
 	libraryID, err := lm.cache.FetchDigest(ctx, lib.Image(), lib.Pull())
 	if err != nil {
 		return "", fmt.Errorf("could not determine library ID: %w", err)
 	}
 
-	// Lock the package. The locker prevents cleanup from running while
-	// we resolve, so we can defer LinkVolume to after we have confirmed
-	// the library is on disk and recorded in the metadata bucket.
+	// Lock the package. The locker prevents cleanup from running while we
+	// resolve, so we can defer LinkVolume to after we have confirmed the
+	// library is on disk and recorded in the metadata bucket.
 	lm.locker.Lock(libraryID)
-	// If linking this volume transfers it away from another library, that
-	// displaced library may now be unused. Schedule its cleanup only after the
-	// target lock above is released: registering this defer before the Unlock
-	// defer makes it run afterwards (defers are LIFO), so an
-	// ImmediateCleanupStrategy never locks the displaced library while we still
-	// hold this one — which would deadlock two opposite re-publishes.
-	var displacedLibraryID string
-	defer func() {
-		if displacedLibraryID != "" {
-			lm.cleanupStrategy.ScheduleCleanup(displacedLibraryID, lm.tryCleanupLibrary)
-		}
-	}()
 	defer lm.locker.Unlock(libraryID)
 
 	// If the library already exists, return it.
@@ -237,7 +251,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	}
 	if path != "" {
 		log.Info("Library already cached", "image", lib.Image(), "path", path)
-		if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name(), true); err != nil {
+		if err = lm.linkVolume(libraryID, volumeID, lib.Name(), true); err != nil {
 			return "", err
 		}
 		result = libraryevents.ResolutionCacheHit
@@ -277,7 +291,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	count, totalBytes, _ := lm.packageStats(lib.Name())
 	lm.listener.OnLibraryCached(lib.Name(), count, totalBytes)
 
-	if displacedLibraryID, err = lm.linkVolume(libraryID, volumeID, lib.Name(), false); err != nil {
+	if err = lm.linkVolume(libraryID, volumeID, lib.Name(), false); err != nil {
 		return "", err
 	}
 
@@ -289,35 +303,14 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 // the resulting per-library volume count. It is intentionally a tiny helper:
 // keeping the listener invocation paired with the LinkVolume call avoids the
 // easy mistake of forgetting one of the two.
-//
-// When the volume was already tracked under a different library (a re-publish
-// without an intervening unlink), LinkVolume transfers the link and decrements
-// the previous library. In that case linkVolume also emits the unlink gauge for
-// the displaced library — while its record still exists — and returns its ID so
-// the caller can schedule its cleanup once the current library lock is
-// released. Cleanup is deliberately not scheduled here: an
-// ImmediateCleanupStrategy would run it synchronously and lock the displaced
-// library while the caller still holds the target library lock, which could
-// deadlock two volumes re-published in opposite directions.
-func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string, fromCache bool) (displacedLibraryID string, err error) {
-	displacedLibraryID, err = lm.db.LinkVolume(libraryID, volumeID, fromCache)
-	if err != nil {
-		return "", err
+func (lm *LibraryManager) linkVolume(libraryID, volumeID, library string, fromCache bool) error {
+	if err := lm.db.LinkVolume(libraryID, volumeID, fromCache); err != nil {
+		return err
 	}
 
 	_, _, volumeLinks := lm.packageStats(library)
 	lm.listener.OnVolumeLinked(library, volumeLinks)
-
-	// The transfer decremented the displaced library's persisted count, so
-	// refresh its gauge now (before any cleanup can remove the record);
-	// otherwise library_volume_links would stay stale until the next restart.
-	if displacedLibraryID != "" {
-		if info, found, gerr := lm.db.GetLibrary(displacedLibraryID); gerr == nil && found && info.Package != "" {
-			_, _, displacedLinks := lm.packageStats(info.Package)
-			lm.listener.OnVolumeUnlinked(info.Package, displacedLinks)
-		}
-	}
-	return displacedLibraryID, nil
+	return nil
 }
 
 // RemoveVolume removes the link between the LibraryID and the VolumeID in the database.

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -155,15 +155,17 @@ func NewLibraryManager(basePath string, opts ...LibraryManagerOption) (*LibraryM
 	return lm, nil
 }
 
-// packageStats reads the per-package aggregates used to label gauge events.
-// Metrics are best-effort: a read error is logged and reported as zeroed
-// stats so a metrics hiccup never fails the mount/unmount that triggered it.
+// packageStats reads the per-package aggregates used to label gauge events by
+// indexing a fresh Snapshot. Metrics are best-effort: a read error is logged
+// and reported as zeroed stats so a metrics hiccup never fails the
+// mount/unmount that triggered it.
 func (lm *LibraryManager) packageStats(library string) (cachedCount int, cachedBytes int64, volumeLinks int) {
-	cachedCount, cachedBytes, volumeLinks, err := lm.db.PackageStats(library)
+	snap, err := lm.db.Snapshot()
 	if err != nil {
 		log.Error("could not read library stats for metrics", "library", library, "error", err)
+		return 0, 0, 0
 	}
-	return cachedCount, cachedBytes, volumeLinks
+	return snap.CachedCountByLibrary[library], snap.CachedBytesByLibrary[library], snap.VolumeLinksByLibrary[library]
 }
 
 // Stop ensures all dependencies are stopped correctly.

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -252,6 +252,13 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		if err != nil {
 			return "", err
 		}
+		// We intentionally do not rewrite the library record here: it already
+		// exists (the volume is linked), so its metadata is left as-is. Known
+		// limitation: if this record was migrated from the legacy schema it has
+		// no package/size, and this recovery path does not backfill it, so it
+		// stays absent from the cached gauges and is cleaned up with an empty
+		// label. This only affects a legacy library that also lost its store
+		// entry and was republished, which is not worth the extra bookkeeping.
 		result = libraryevents.ResolutionDownloaded
 		return storePath, nil
 	}

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -219,17 +219,32 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		lm.locker.Lock(existingLibraryID)
 		defer lm.locker.Unlock(existingLibraryID)
 
-		// An active link guarantees the library is still on disk: cleanup only
-		// removes a library once its volume count reaches zero. Any error here
-		// (including ErrItemNotFound) is therefore unexpected and surfaces as a
-		// publish failure rather than being treated as a cache miss.
+		// The volume is already linked: reuse its library instead of
+		// re-resolving the image.
 		path, err := lm.store.Get(existingLibraryID)
+		if err != nil && !errors.Is(err, ErrItemNotFound) {
+			return "", err
+		}
+		if path != "" {
+			log.Info("Reusing library already linked to volume", "image", lib.Image(), "path", path)
+			result = libraryevents.ResolutionCacheHit
+			return path, nil
+		}
+
+		// The link points at a library that is no longer on disk. Cleanup only
+		// removes a library once it has no links, so this means the store was
+		// emptied out from under us (host disk cleanup or corruption while the
+		// DB file survived). Re-download the exact same content by digest so
+		// the volume keeps the library it is linked to; the DB still references
+		// it, so no metadata or link needs to change.
+		image := fmt.Sprintf("%s/%s@sha256:%s", lib.Registry(), lib.Name(), existingLibraryID)
+		log.Warn("Linked library missing from store, redownloading", "library_id", existingLibraryID, "image", image)
+		storePath, _, err := lm.downloadToStore(ctx, existingLibraryID, lib, image)
 		if err != nil {
 			return "", err
 		}
-		log.Info("Reusing library already linked to volume", "image", lib.Image(), "path", path)
-		result = libraryevents.ResolutionCacheHit
-		return path, nil
+		result = libraryevents.ResolutionDownloaded
+		return storePath, nil
 	}
 
 	// Fetch the library ID based on the image digest.
@@ -258,28 +273,11 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return path, nil
 	}
 
-	// Otherwise, create a scratch space.
-	scratch, err := afero.TempDir(lm.fs, lm.scratchDir, "datadog-csi-driver-*")
-	if err != nil {
-		return "", fmt.Errorf("could not create scratch directory: %w", err)
-	}
-	defer func() { _ = lm.fs.RemoveAll(scratch) }()
-
-	// Download the library into the scratch space.
-	log.Info("Downloading library", "image", lib.Image())
-	downloadStart := time.Now()
-	sizeBytes, err := lm.downloader.Download(ctx, lm.fs, lib.Image(), scratch)
+	// Otherwise, download the library and copy it into the store.
+	storePath, sizeBytes, err := lm.downloadToStore(ctx, libraryID, lib, lib.Image())
 	if err != nil {
 		return "", err
 	}
-	lm.listener.OnLibraryDownload(lib.Name(), lib.Registry(), time.Since(downloadStart))
-
-	// Copy the library into the store.
-	storePath, err := lm.store.Add(libraryID, scratch)
-	if err != nil {
-		return "", err
-	}
-	log.Info("Library downloaded and stored", "image", lib.Image(), "path", storePath)
 
 	// Record the library so its package name and on-disk size are persisted.
 	// AddLibrary is the canonical writer for the per-library record; it must
@@ -297,6 +295,35 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 
 	result = libraryevents.ResolutionDownloaded
 	return storePath, nil
+}
+
+// downloadToStore pulls image into a fresh scratch directory and copies it into
+// the store under libraryID, returning the resulting store path and on-disk
+// size. The caller must hold the library lock. It emits the download event but
+// performs no metadata or link bookkeeping, so it is shared by the cache-miss
+// download path and the recovery path that restores a linked library whose
+// store entry disappeared.
+func (lm *LibraryManager) downloadToStore(ctx context.Context, libraryID string, lib *Library, image string) (string, int64, error) {
+	scratch, err := afero.TempDir(lm.fs, lm.scratchDir, "datadog-csi-driver-*")
+	if err != nil {
+		return "", 0, fmt.Errorf("could not create scratch directory: %w", err)
+	}
+	defer func() { _ = lm.fs.RemoveAll(scratch) }()
+
+	log.Info("Downloading library", "image", image)
+	downloadStart := time.Now()
+	sizeBytes, err := lm.downloader.Download(ctx, lm.fs, image, scratch)
+	if err != nil {
+		return "", 0, err
+	}
+	lm.listener.OnLibraryDownload(lib.Name(), lib.Registry(), time.Since(downloadStart))
+
+	storePath, err := lm.store.Add(libraryID, scratch)
+	if err != nil {
+		return "", 0, err
+	}
+	log.Info("Library downloaded and stored", "image", image, "path", storePath)
+	return storePath, sizeBytes, nil
 }
 
 // linkVolume persists the library/volume link and notifies the listener with

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -206,6 +206,15 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 		return "", fmt.Errorf("library cannot be nil")
 	}
 
+	// Serialize the whole resolve/download/link sequence per volume. The
+	// library lock below only excludes operations on the same library, so two
+	// concurrent publishes for the same volume whose mutable tag resolves to
+	// different digests would otherwise lock different libraries, both link,
+	// and leave the volume mounting one library while the DB records the other.
+	// The key is namespaced so it never collides with a library digest lock.
+	lm.locker.Lock(volumeLockKey(volumeID))
+	defer lm.locker.Unlock(volumeLockKey(volumeID))
+
 	// A volume is published once and keeps the same library for its whole
 	// lifetime. If it is already linked, resolve it from its existing record
 	// instead of re-resolving the image: this makes NodePublishVolume
@@ -295,6 +304,12 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 
 	result = libraryevents.ResolutionDownloaded
 	return storePath, nil
+}
+
+// volumeLockKey namespaces a volume ID so its serialization lock can never
+// collide with a library lock, which is keyed by the raw image digest.
+func volumeLockKey(volumeID string) string {
+	return "volume:" + volumeID
 }
 
 // downloadToStore pulls image into a fresh scratch directory and copies it into

--- a/pkg/librarymanager/testdata/README.md
+++ b/pkg/librarymanager/testdata/README.md
@@ -30,7 +30,7 @@ func TestCreateTestDatabase(t *testing.T) {
 
 	volumeID := "test-volume-id"
 	libraryID := "test-library-id"
-	_, err = db.LinkVolume(libraryID, volumeID)
+	_, err = db.LinkVolume(libraryID, volumeID, false)
 	require.NoError(t, err)
 }
 ```

--- a/pkg/librarymanager/testdata/README.md
+++ b/pkg/librarymanager/testdata/README.md
@@ -30,7 +30,7 @@ func TestCreateTestDatabase(t *testing.T) {
 
 	volumeID := "test-volume-id"
 	libraryID := "test-library-id"
-	_, err = db.LinkVolume(libraryID, volumeID, false)
+	err = db.LinkVolume(libraryID, volumeID, false)
 	require.NoError(t, err)
 }
 ```

--- a/pkg/librarymanager/testdata/README.md
+++ b/pkg/librarymanager/testdata/README.md
@@ -30,7 +30,7 @@ func TestCreateTestDatabase(t *testing.T) {
 
 	volumeID := "test-volume-id"
 	libraryID := "test-library-id"
-	err = db.LinkVolume(libraryID, volumeID)
+	_, err = db.LinkVolume(libraryID, volumeID)
 	require.NoError(t, err)
 }
 ```


### PR DESCRIPTION
### What does this PR do?

Simplifies the `librarymanager` storage layer that backs the library lifecycle metrics.

- Replaces the nested `library-mappings`/`volume-mappings` buckets and the separate `library-metadata` bucket with two flat buckets: `volumes` (volumeID → libraryID) and `libraries` (libraryID → {package, size, volume count}).
- Replaces the per-library volume sub-buckets with a reference count on the library record.
- Removes the in-memory aggregate caches (and their lock + rollback bookkeeping): per-package metric aggregates are now derived on demand from the `libraries` bucket via a single `Snapshot` scan, which is cheap given a node only caches a handful of libraries.
- Simplifies the unmount path: `UnlinkVolume` returns the library ID and package name it read while decrementing the count, so no extra lookups are needed.
- Migrates existing databases (1.2.x schema) in place on first start, preserving volume links and library metadata.
- The `libraryevents.Listener` interface and the Prometheus implementation are unchanged from `main`.

### Motivation

The metrics work had grown a complex storage layer: a dual representation (bbolt buckets + in-memory aggregate maps kept eventually consistent), with the same increment/commit/rollback dance duplicated across every write, plus a metadata bucket whose only purpose was to recover the package label at unmount. The goal here is simplicity and readability: one source of truth, derive aggregates on demand, and keep responsibilities well segmented.

### Additional Notes

- The on-disk schema change is safe across upgrades thanks to the in-place migration (covered by tests). Metrics have not been released yet, so the format change has no external impact.
- Behaviour and the metrics surface (names, labels) are unchanged.

### Describe your test plan

- `go test ./...`
- Database unit tests: CRUD, ref counting, idempotency, snapshot aggregation, and legacy-schema migration.
- Library manager event tests (new): a recording listener asserts the lifecycle wiring — resolution (downloaded/cache_hit/failed), cached, linked, unlinked, eviction, cleanup (success/skipped_in_use), snapshot seeding on restart, no-op removal of an untracked volume, and cleanup of a migrated library without metadata.
- Metrics listener tests: each event maps to the expected gauge/counter.

#### Manual end-to-end verification (local minikube)

Verified the metrics surface against a real driver running in minikube, with an auto-instrumented `php-containers` pod mounting 5 `DatadogLibrary` volumes (`apm-inject`, `dd-lib-dotnet-init`, `dd-lib-js-init`, `dd-lib-php-init`, `dd-lib-python-init`). Metrics scraped from the driver's `/metrics` endpoint (`:5000`). The `delayed` cleanup strategy was temporarily lowered to 30s to exercise time-based cleanup quickly.

| # | Scenario | Action | Observed metrics |
|---|----------|--------|------------------|
| 1 | Cache hit + ref counting | Scale pod 1 → 2 | `library_volume_links` → 2 per library; `library_resolutions_total{result="cache_hit"}` +1 per library; `libraries_cached` stays 1 (no re-store) |
| 2 | Cleanup skipped (still in use) | Scale 2 → 1 | `library_volume_links` → 1 immediately; ~30s later `library_cleanup_total{status="skipped_in_use",strategy="delayed"}` +1 per library; cached gauges unchanged |
| 3 | Eviction (last link removed) | Scale 1 → 0 | `library_volume_links` → 0 immediately; ~30s later `library_cleanup_total{status="success",strategy="delayed"}` +1 per library; `libraries_cached` and `libraries_cached_bytes` → 0; on-disk store emptied |
| 4 | Download (cache miss) | Scale 0 → 1 after eviction | `library_resolutions_total{result="downloaded"}` +1 per library; `library_download_duration_seconds` observed per library; `libraries_cached` → 1 |
| 5 | Resolution failure | Pod referencing a non-existent package | `library_resolutions_total{library="dd-lib-bogus-init",result="failed"}`; `node_publish_volume_attempts{status="failed",type="DatadogLibrary"}`; `library` label populated even on failure |
| 6 | Reseed on restart | `rollout restart` of the driver DaemonSet | Gauges (`libraries_cached`, `libraries_cached_bytes`, `library_volume_links`) repopulated from the persisted bbolt DB via `OnSnapshot`; counters reset (per-process), as expected |

Notes:
- The store and DB persist across driver restarts (hostPath-backed storage dir), so a simple restart does not trigger re-downloads.
- On shutdown, `Stop()` flushes any pending delayed cleanups; those counters live with the terminating process.
