### PR TITLE
fix(librarymanager): harden archive extraction

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Go",
-    "image": "mcr.microsoft.com/devcontainers/go:1-1.24",
+    "image": "mcr.microsoft.com/devcontainers/go:1-1.25",
     "features": {
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
         "ghcr.io/devcontainers-contrib/features/kubectx-kubens": {},

--- a/.github/workflows/golang-ci-linter.yaml
+++ b/.github/workflows/golang-ci-linter.yaml
@@ -30,8 +30,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Lint code
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+        uses: golangci/golangci-lint-action@7119f3d5ddced62a10a044847a6c6bb0f7a5e76a # v7.0.0
         with:
-          version: v1.64.8
+          version: v2.4.0
           only-new-issues: false
           args: ./...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 include:
   - local: .adms/go/gitlab.yaml
 # Go version is defined in go.mod - this image is used as fallback
-image: registry.ddbuild.io/images/mirror/golang:1.24
+image: registry.ddbuild.io/images/mirror/golang:1.25
 variables:
   PROJECTNAME: "datadog-csi-driver"
   BUILD_DOCKER_REGISTRY: "registry.ddbuild.io/ci"
@@ -21,7 +21,7 @@ stages:
 
 tests:
   stage: test
-  image: registry.ddbuild.io/images/mirror/golang:1.24
+  image: registry.ddbuild.io/images/mirror/golang:1.25
   tags: ["arch:amd64"]
   script:
     - make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,24 +1,24 @@
+version: "2"
+
 run:
   timeout: 10m
   modules-download-mode: readonly
   tests: false
 
-issues:
-  exclude-files:
-    - "testing.go"
-    - ".*\\.pb\\.go"
-    - ".*\\.gen\\.go"
-
 linters:
   enable:
     - goheader
+  exclusions:
+    paths:
+      - "testing.go"
+      - ".*\\.pb\\.go"
+      - ".*\\.gen\\.go"
+  settings:
+    misspell:
+      locale: US
+    goheader:
+      template: |-
+        Datadog datadog-csi driver
+        Copyright 2025-present Datadog, Inc.
 
-linters-settings:
-  misspell:
-    locale: US
-  goheader:
-    template: |-
-      Datadog datadog-csi driver
-      Copyright 2025-present Datadog, Inc.
-
-      This product includes software developed at Datadog (https://www.datadoghq.com/).
+        This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LinkVolume` now happens after the library has been confirmed on disk (cache hit) or recorded in the metadata bucket (successful download). This prevents dangling links if the download fails, and gives `library_volume_links` a stable library label.
 - `RemoveVolume` is now a no-op when the volume was never linked.
 
+### Fixed
+
+- Fixed OCI archive extraction for `DatadogLibrary` volumes to prevent archive-planted symlinks from redirecting file writes outside the extraction directory.
+
 ### Notes
 
 - Libraries cached on disk before this release have no metadata recorded; they are not counted in the `libraries_cached*` or `library_volume_links` gauges until they are downloaded again. The bias is expected to be short-lived because the library publisher is not yet in heavy use.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is already multi-architecture, supporting both amd64 and arm64.
 # GO_VERSION should match the toolchain version in go.mod
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/Datadog/datadog-csi-driver
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.11
+toolchain go1.25.5
 
 require (
 	github.com/container-storage-interface/spec v1.11.0

--- a/pkg/driver/publishers/utils.go
+++ b/pkg/driver/publishers/utils.go
@@ -32,7 +32,9 @@ func createHostPath(fs afero.Afero, pathname string, isFile bool) error {
 				log.Error("Failed to create file", "error", err, "path", pathname)
 				return status.Errorf(codes.Internal, "Cannot create file: %v", err)
 			}
-			defer file.Close() // Ensure the file gets closed after creation
+			defer func() {
+				_ = file.Close()
+			}() // Ensure the file gets closed after creation
 			log.Info("Successfully created file", "path", pathname)
 		} else {
 			log.Info("Directory does not exist, creating", "path", pathname)

--- a/pkg/librarymanager/archive.go
+++ b/pkg/librarymanager/archive.go
@@ -55,7 +55,9 @@ func (fp *ArchiveExtractor) Extract(ctx context.Context, reader io.Reader) (int6
 	if err != nil {
 		return 0, fmt.Errorf("could not open destination root %s: %w", fp.dst, err)
 	}
-	defer root.Close()
+	defer func() {
+		_ = root.Close()
+	}()
 	fp.root = root
 	defer func() { fp.root = nil }()
 
@@ -85,7 +87,7 @@ func (fp *ArchiveExtractor) processFile(ctx context.Context, f archives.FileInfo
 		return nil
 	}
 
-	mode := f.FileInfo.Mode()
+	mode := f.Mode()
 	switch {
 	case mode.IsDir():
 		return fp.root.Mkdir(destPath, 0o755)
@@ -111,13 +113,17 @@ func (fp *ArchiveExtractor) processFile(ctx context.Context, f archives.FileInfo
 		if err != nil {
 			return fmt.Errorf("could not open file in archive: %w", err)
 		}
-		defer in.Close()
+		defer func() {
+			_ = in.Close()
+		}()
 
 		out, err := fp.root.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
 		if err != nil {
 			return fmt.Errorf("could not create destination file: %w", err)
 		}
-		defer out.Close()
+		defer func() {
+			_ = out.Close()
+		}()
 
 		n, err := io.Copy(out, in)
 		if err != nil {

--- a/pkg/librarymanager/archive.go
+++ b/pkg/librarymanager/archive.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/mholt/archives"
-	"github.com/spf13/afero"
 )
 
 // ArchiveExtractor extracts directories from a tar archive.
@@ -31,12 +30,12 @@ type ArchiveExtractor struct {
 }
 
 // NewArchiveExtractor initializes a new archive extractor.
-func NewArchiveExtractor(afs afero.Afero, src string, dst string) (*ArchiveExtractor, error) {
+func NewArchiveExtractor(src string, dst string) (*ArchiveExtractor, error) {
 	destination, err := filepath.Abs(filepath.Clean(dst))
 	if err != nil {
 		return nil, fmt.Errorf("could not get absolute path for destination %s: %w", dst, err)
 	}
-	if err := afs.MkdirAll(destination, 0o755); err != nil {
+	if err := os.MkdirAll(destination, 0o755); err != nil {
 		return nil, fmt.Errorf("could not create destination %s: %w", destination, err)
 	}
 	return &ArchiveExtractor{

--- a/pkg/librarymanager/archive.go
+++ b/pkg/librarymanager/archive.go
@@ -20,13 +20,14 @@ import (
 // ArchiveExtractor extracts directories from a tar archive.
 type ArchiveExtractor struct {
 	src    string
-	dst    string      // Absolute path to destination (needed for symlinks, as afero doesn't support them)
-	dstFs  afero.Afero // BasePathFs rooted at destination
+	dst    string // Absolute path to destination
 	format archives.Tar
 
 	// bytesExtracted tracks the cumulative size of regular files written
 	// during Extract. Reset on each Extract call.
 	bytesExtracted int64
+
+	root *os.Root
 }
 
 // NewArchiveExtractor initializes a new archive extractor.
@@ -35,12 +36,12 @@ func NewArchiveExtractor(afs afero.Afero, src string, dst string) (*ArchiveExtra
 	if err != nil {
 		return nil, fmt.Errorf("could not get absolute path for destination %s: %w", dst, err)
 	}
-	// Create a BasePathFs rooted at the destination to prevent path traversal
-	baseFs := afero.NewBasePathFs(afs.Fs, destination)
+	if err := afs.MkdirAll(destination, 0o755); err != nil {
+		return nil, fmt.Errorf("could not create destination %s: %w", destination, err)
+	}
 	return &ArchiveExtractor{
 		src:    filepath.Clean("/" + src),
 		dst:    destination,
-		dstFs:  afero.Afero{Fs: baseFs},
 		format: archives.Tar{},
 	}, nil
 }
@@ -50,6 +51,14 @@ func NewArchiveExtractor(afs afero.Afero, src string, dst string) (*ArchiveExtra
 // the regular files written; symlinks and directories are not counted.
 func (fp *ArchiveExtractor) Extract(ctx context.Context, reader io.Reader) (int64, error) {
 	fp.bytesExtracted = 0
+	root, err := os.OpenRoot(fp.dst)
+	if err != nil {
+		return 0, fmt.Errorf("could not open destination root %s: %w", fp.dst, err)
+	}
+	defer root.Close()
+	fp.root = root
+	defer func() { fp.root = nil }()
+
 	if err := fp.format.Extract(ctx, reader, fp.processFile); err != nil {
 		return 0, err
 	}
@@ -76,11 +85,10 @@ func (fp *ArchiveExtractor) processFile(ctx context.Context, f archives.FileInfo
 		return nil
 	}
 
-	// The dstFs is a BasePathFs rooted at the destination, preventing path traversal
 	mode := f.FileInfo.Mode()
 	switch {
 	case mode.IsDir():
-		return fp.dstFs.Mkdir(destPath, 0o755)
+		return fp.root.Mkdir(destPath, 0o755)
 	case mode&os.ModeSymlink != 0:
 		// Handle symbolic links.
 		// Some packages use symlinks (e.g., dd-lib-python-init for deduplication, apm-inject for versioning).
@@ -90,16 +98,9 @@ func (fp *ArchiveExtractor) processFile(ctx context.Context, f archives.FileInfo
 		if linkTarget == "" {
 			return fmt.Errorf("symlink %s has no target", destPath)
 		}
-		fullDestPath := filepath.Clean(filepath.Join(fp.dst, destPath))
-		// Verify the path stays within the destination root
-		if !strings.HasPrefix(fullDestPath, fp.dst+string(filepath.Separator)) {
-			return fmt.Errorf("symlink path %q escapes destination directory", destPath)
-		}
-		// Create the symlink in the destination.
-		// Note: afero does not support symlinks, so we use os.Symlink directly.
-		if err := os.Symlink(linkTarget, fullDestPath); err != nil {
+		if err := fp.root.Symlink(linkTarget, destPath); err != nil {
 			// If symlink already exists with the same target, ignore the error
-			if existing, readErr := os.Readlink(fullDestPath); readErr == nil && existing == linkTarget {
+			if existing, readErr := fp.root.Readlink(destPath); readErr == nil && existing == linkTarget {
 				return nil
 			}
 			return fmt.Errorf("could not create symlink %s -> %s: %w", destPath, linkTarget, err)
@@ -112,7 +113,7 @@ func (fp *ArchiveExtractor) processFile(ctx context.Context, f archives.FileInfo
 		}
 		defer in.Close()
 
-		out, err := fp.dstFs.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+		out, err := fp.root.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
 		if err != nil {
 			return fmt.Errorf("could not create destination file: %w", err)
 		}

--- a/pkg/librarymanager/archive_test.go
+++ b/pkg/librarymanager/archive_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
 	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +68,7 @@ func TestExtract(t *testing.T) {
 
 			// Extract archive.
 			ctx := context.Background()
-			ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, test.source, tsd.Path(t))
+			ae, err := librarymanager.NewArchiveExtractor(test.source, tsd.Path(t))
 			require.NoError(t, err, "could not setup extractor")
 			_, err = ae.Extract(ctx, f)
 			require.NoError(t, err, "could not extract archive")
@@ -108,7 +107,7 @@ func TestExtractSymlink(t *testing.T) {
 	defer f.Close()
 
 	ctx := context.Background()
-	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
+	ae, err := librarymanager.NewArchiveExtractor("/", tsd.Path(t))
 	require.NoError(t, err)
 	_, err = ae.Extract(ctx, f)
 	require.NoError(t, err)
@@ -156,7 +155,7 @@ func TestExtractSymlinkPathTraversal(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
+			ae, err := librarymanager.NewArchiveExtractor("/", tsd.Path(t))
 			require.NoError(t, err)
 
 			// Extraction should succeed - malicious paths are normalized, not rejected
@@ -203,7 +202,7 @@ func TestExtractDoesNotFollowSymlinkOutsideDestination(t *testing.T) {
 	tsd := testutil.NewTempScratchDirectory(t)
 	defer tsd.Cleanup(t)
 
-	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
+	ae, err := librarymanager.NewArchiveExtractor("/", tsd.Path(t))
 	require.NoError(t, err)
 	_, err = ae.Extract(context.Background(), &archive)
 	require.Error(t, err)
@@ -229,7 +228,7 @@ func TestExtractSymlinkIdempotent(t *testing.T) {
 	defer tsd.Cleanup(t)
 
 	ctx := context.Background()
-	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
+	ae, err := librarymanager.NewArchiveExtractor("/", tsd.Path(t))
 	require.NoError(t, err)
 
 	// First extraction
@@ -250,7 +249,7 @@ func TestExtractSymlinkIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	defer f2.Close()
 
-	ae2, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
+	ae2, err := librarymanager.NewArchiveExtractor("/", tsd.Path(t))
 	require.NoError(t, err)
 	_, err = ae2.Extract(ctx, f2)
 	require.NoError(t, err, "second extraction should succeed when symlink already exists with same target")
@@ -281,7 +280,7 @@ func TestExtractSymlinkNoTarget(t *testing.T) {
 	defer archive.Close()
 
 	ctx := context.Background()
-	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
+	ae, err := librarymanager.NewArchiveExtractor("/", tsd.Path(t))
 	require.NoError(t, err)
 
 	_, err = ae.Extract(ctx, archive)

--- a/pkg/librarymanager/archive_test.go
+++ b/pkg/librarymanager/archive_test.go
@@ -7,6 +7,7 @@ package librarymanager_test
 
 import (
 	"archive/tar"
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -175,6 +176,40 @@ func TestExtractSymlinkPathTraversal(t *testing.T) {
 			require.True(t, os.IsNotExist(err), "no file should be created outside destination directory")
 		})
 	}
+}
+
+func TestExtractDoesNotFollowSymlinkOutsideDestination(t *testing.T) {
+	outside := t.TempDir()
+	victim := filepath.Join(outside, "pwned")
+
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "evil",
+		Typeflag: tar.TypeSymlink,
+		Linkname: outside,
+		Mode:     0777,
+	}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "evil/pwned",
+		Typeflag: tar.TypeReg,
+		Mode:     0644,
+		Size:     int64(len("owned")),
+	}))
+	_, err := tw.Write([]byte("owned"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	tsd := testutil.NewTempScratchDirectory(t)
+	defer tsd.Cleanup(t)
+
+	ae, err := librarymanager.NewArchiveExtractor(afero.Afero{Fs: afero.NewOsFs()}, "/", tsd.Path(t))
+	require.NoError(t, err)
+	_, err = ae.Extract(context.Background(), &archive)
+	require.Error(t, err)
+
+	_, err = os.ReadFile(victim)
+	require.True(t, os.IsNotExist(err), "extracting through a symlink must not write outside the destination")
 }
 
 func TestExtractSymlinkIdempotent(t *testing.T) {

--- a/pkg/librarymanager/downloader.go
+++ b/pkg/librarymanager/downloader.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/spf13/afero"
 )
 
 const (
@@ -42,7 +41,7 @@ func NewDownloaderWithRoundTripper(roundTripper http.RoundTripper) *Downloader {
 
 // Download will stream a container image and extract the source directory from inside of the image to the destination
 // directory on disk. Returns the cumulative size of the regular files written.
-func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string, dst string) (int64, error) {
+func (d *Downloader) Download(ctx context.Context, image string, dst string) (int64, error) {
 	img, err := crane.Pull(image,
 		crane.WithContext(ctx),
 		crane.WithUserAgent(userAgent),
@@ -59,7 +58,7 @@ func (d *Downloader) Download(ctx context.Context, afs afero.Afero, image string
 	}()
 
 	// Extract the entire image content
-	fp, err := NewArchiveExtractor(afs, "/", dst)
+	fp, err := NewArchiveExtractor("/", dst)
 	if err != nil {
 		return 0, fmt.Errorf("could not setup archive extractor: %w", err)
 	}

--- a/pkg/librarymanager/downloader_test.go
+++ b/pkg/librarymanager/downloader_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
 	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,7 +53,7 @@ func TestDownload(t *testing.T) {
 			require.Equal(t, test.expectedDigest, digest)
 
 			// Ensure downloaded files match the expected.
-			_, err = d.Download(ctx, afero.Afero{Fs: afero.NewOsFs()}, image, tsd.Path(t))
+			_, err = d.Download(ctx, image, tsd.Path(t))
 			require.NoError(t, err, "error found when downloading")
 
 			// Ensure expected files exist.

--- a/pkg/librarymanager/librarymanager.go
+++ b/pkg/librarymanager/librarymanager.go
@@ -225,7 +225,7 @@ func (lm *LibraryManager) GetLibraryForVolume(ctx context.Context, volumeID stri
 	// Download the library into the scratch space.
 	log.Info("Downloading library", "image", lib.Image())
 	downloadStart := time.Now()
-	sizeBytes, err := lm.downloader.Download(ctx, lm.fs, lib.Image(), scratch)
+	sizeBytes, err := lm.downloader.Download(ctx, lib.Image(), scratch)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Description

Hardens library archive extraction and updates the Go toolchain used to build it.

## Related Issue

https://datadoghq.atlassian.net/browse/INPLAT-1174

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [x] CI / tooling
- [ ] Documentation

## Checklist

- [x] Documentation updated if needed
- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- `go test ./pkg/librarymanager -count=1`
- `go test ./...`