### PR TITLE
fix(publishers): validate library source path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LinkVolume` now happens after the library has been confirmed on disk (cache hit) or recorded in the metadata bucket (successful download). This prevents dangling links if the download fails, and gives `library_volume_links` a stable library label.
 - `RemoveVolume` is now a no-op when the volume was never linked.
 
+### Fixed
+
+- Fixed `DatadogLibrary` volume publishing to reject library source paths that resolve outside the downloaded library directory.
+
 ### Notes
 
 - Libraries cached on disk before this release have no metadata recorded; they are not counted in the `libraries_cached*` or `library_volume_links` gauges until they are downloaded again. The bias is expected to be short-lived because the library publisher is not yet in heavy use.
@@ -33,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `DatadogLibrary` volume publishing to reject library source paths that resolve outside the downloaded library directory.
 - Fixed driver startup to disable SSI publishers when `storageBasePath` is not writable instead of failing initialization
 
 ## [1.2.1] - 2026-02-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `DatadogLibrary` volume publishing to reject library source paths that resolve outside the downloaded library directory.
 - Fixed driver startup to disable SSI publishers when `storageBasePath` is not writable instead of failing initialization
 
 ## [1.2.1] - 2026-02-03

--- a/pkg/driver/publishers/library.go
+++ b/pkg/driver/publishers/library.go
@@ -138,8 +138,33 @@ func (s libraryPublisher) getLibraryPath(volumeCtx map[string]string, volumeID s
 	// Remove leading slash from source to join paths correctly
 	source = strings.TrimPrefix(source, "/")
 	path = filepath.Join(basePath, source)
+	path, err = validateLibrarySourcePath(basePath, path)
+	if err != nil {
+		return "", lib.Image(), err
+	}
 
 	return path, lib.Image(), nil
+}
+
+// validateLibrarySourcePath resolves the bind-mount source and ensures it
+// remains inside the downloaded library directory.
+func validateLibrarySourcePath(basePath, sourcePath string) (string, error) {
+	resolvedBasePath, err := filepath.EvalSymlinks(basePath)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve library base path: %w", err)
+	}
+	resolvedSourcePath, err := filepath.EvalSymlinks(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve library source path: %w", err)
+	}
+	relativePath, err := filepath.Rel(resolvedBasePath, resolvedSourcePath)
+	if err != nil {
+		return "", fmt.Errorf("could not validate library source path: %w", err)
+	}
+	if relativePath == "." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) || relativePath == ".." {
+		return "", fmt.Errorf("library source path %q resolves outside library base path", sourcePath)
+	}
+	return resolvedSourcePath, nil
 }
 
 func newLibraryPublisher(fs afero.Afero, mounter mount.Interface, libraryManager *librarymanager.LibraryManager, disabled bool, allowedRegistries []string) Publisher {

--- a/pkg/driver/publishers/library.go
+++ b/pkg/driver/publishers/library.go
@@ -140,6 +140,9 @@ func (s libraryPublisher) getLibraryPath(volumeCtx map[string]string, volumeID s
 	path = filepath.Join(basePath, source)
 	path, err = validateLibrarySourcePath(basePath, path)
 	if err != nil {
+		if removeErr := s.libraryManager.RemoveVolume(context.Background(), volumeID); removeErr != nil {
+			return "", lib.Image(), fmt.Errorf("%w; additionally failed to roll back volume link: %v", err, removeErr)
+		}
 		return "", lib.Image(), err
 	}
 

--- a/pkg/driver/publishers/library_test.go
+++ b/pkg/driver/publishers/library_test.go
@@ -249,6 +249,9 @@ func TestLibraryPublisher_Publish_RejectsSymlinkedLibrarySource(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "library source path")
 	assert.Empty(t, mounter.GetLog(), "publish must reject the source before bind mounting")
+	hasVolume, err := lm.HasVolume(req.GetVolumeId())
+	require.NoError(t, err)
+	assert.False(t, hasVolume, "failed publish must not leave the volume linked")
 }
 
 func TestRegistryAllowed(t *testing.T) {

--- a/pkg/driver/publishers/library_test.go
+++ b/pkg/driver/publishers/library_test.go
@@ -6,6 +6,7 @@
 package publishers
 
 import (
+	"archive/tar"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,10 @@ import (
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
 	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,6 +213,44 @@ func TestLibraryPublisher_Publish_Success(t *testing.T) {
 		"mount source should contain library path, got: %s", mountLog[0].Source)
 }
 
+func TestLibraryPublisher_Publish_RejectsSymlinkedLibrarySource(t *testing.T) {
+	localRegistry := testutil.NewLocalRegistry(t)
+	defer localRegistry.Stop()
+	imageTar := createSymlinkedLibrarySourceImage(t, "/")
+	localRegistry.AddImage(t, imageTar, "symlinked-library", "v1.0.0")
+
+	basePath := t.TempDir()
+	fs := afero.Afero{Fs: afero.NewOsFs()}
+	lm, err := librarymanager.NewLibraryManager(basePath,
+		librarymanager.WithFilesystem(fs),
+		librarymanager.WithDownloader(librarymanager.NewDownloaderWithRoundTripper(localRegistry.GetRoundTripper(t))),
+	)
+	require.NoError(t, err)
+	defer lm.Stop()
+
+	mounter := mount.NewFakeMounter(nil)
+	publisher := newLibraryPublisher(fs, mounter, lm, false, nil)
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   "test-volume-symlinked-source",
+		TargetPath: filepath.Join(t.TempDir(), "target", "library"),
+		Readonly:   true,
+		VolumeContext: map[string]string{
+			"type":                                "DatadogLibrary",
+			"dd.csi.datadog.com/library.package":  "symlinked-library",
+			"dd.csi.datadog.com/library.registry": localRegistry.Registry(t),
+			"dd.csi.datadog.com/library.version":  "v1.0.0",
+		},
+	}
+
+	resp, err := publisher.Publish(req)
+
+	require.NotNil(t, resp)
+	assert.Equal(t, DatadogLibrary, resp.VolumeType)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "library source path")
+	assert.Empty(t, mounter.GetLog(), "publish must reject the source before bind mounting")
+}
+
 func TestRegistryAllowed(t *testing.T) {
 	tests := map[string]struct {
 		registry      string
@@ -242,6 +285,51 @@ func TestRegistryAllowed(t *testing.T) {
 			assert.Equal(t, tc.expectAllowed, publisher.registryAllowed(tc.registry))
 		})
 	}
+}
+
+func createSymlinkedLibrarySourceImage(t *testing.T, linkTarget string) string {
+	t.Helper()
+
+	rootfs := filepath.Join(t.TempDir(), "rootfs.tar")
+	f, err := os.Create(rootfs)
+	require.NoError(t, err)
+
+	tw := tar.NewWriter(f)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "datadog-init",
+		Typeflag: tar.TypeDir,
+		Mode:     0755,
+	}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "datadog-init/package",
+		Typeflag: tar.TypeSymlink,
+		Linkname: linkTarget,
+		Mode:     0777,
+	}))
+	require.NoError(t, tw.Close())
+	require.NoError(t, f.Close())
+
+	imageTar := filepath.Join(t.TempDir(), "image.tar")
+	require.NoError(t, tarballImage(t, rootfs, imageTar))
+	return imageTar
+}
+
+func tarballImage(t *testing.T, rootfsTar, imageTar string) error {
+	t.Helper()
+
+	layer, err := tarball.LayerFromFile(rootfsTar)
+	if err != nil {
+		return err
+	}
+	img, err := mutate.Append(empty.Image, mutate.Addendum{Layer: layer})
+	if err != nil {
+		return err
+	}
+	ref, err := name.NewTag("test-image:latest")
+	if err != nil {
+		return err
+	}
+	return tarball.WriteToFile(imageTar, ref, img)
 }
 
 func TestLibraryPublisher_Publish_RegistryAllowList(t *testing.T) {


### PR DESCRIPTION
## Description

Adds validation before publishing DatadogLibrary sources and rejects paths that resolve outside the downloaded library directory.

## Related Issue

https://datadoghq.atlassian.net/browse/INPLAT-1175

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [x] Documentation updated if needed
- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- `go test ./pkg/driver/publishers -run TestLibraryPublisher_Publish_RejectsSymlinkedLibrarySource -count=1`
- `go test ./pkg/driver/publishers -count=1`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...`