### PR TITLE
fix(publishers): remount library volumes read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LinkVolume` now happens after the library has been confirmed on disk (cache hit) or recorded in the metadata bucket (successful download). This prevents dangling links if the download fails, and gives `library_volume_links` a stable library label.
 - `RemoveVolume` is now a no-op when the volume was never linked.
 
+### Fixed
+
+- Fixed `DatadogLibrary` and `DatadogInjectorPreload` volume publishing to remount bind mounts as read-only.
+
 ### Notes
 
 - Libraries cached on disk before this release have no metadata recorded; they are not counted in the `libraries_cached*` or `library_volume_links` gauges until they are downloaded again. The bias is expected to be short-lived because the library publisher is not yet in heavy use.

--- a/pkg/driver/publishers/bindmount.go
+++ b/pkg/driver/publishers/bindmount.go
@@ -10,10 +10,15 @@ import (
 	"os"
 
 	"github.com/spf13/afero"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/utils/mount"
 )
+
+var remountReadOnlyBind = func(hostPath, targetPath string) error {
+	return unix.Mount(hostPath, targetPath, "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, "")
+}
 
 // bindMount performs a bind mount from hostPath to targetPath.
 // It creates the target path if it doesn't exist (as file if isFile, directory otherwise).
@@ -45,17 +50,21 @@ func bindMount(afs afero.Afero, mounter mount.Interface, hostPath, targetPath st
 
 	// Perform bind mount if not already mounted
 	if notMnt {
-		if err := mounter.Mount(hostPath, targetPath, "", []string{"bind"}); err != nil {
+		options := []string{"bind"}
+		if readOnly {
+			options = append(options, "ro")
+		}
+		if err := mounter.Mount(hostPath, targetPath, "", options); err != nil {
 			slog.Error("bindMount: failed to mount", "error", err, "host_path", hostPath, "target_path", targetPath)
 			return status.Errorf(codes.Internal, "bindMount: failed to mount: %v", err)
 		}
 	} else {
 		slog.Info("bindMount: already mounted, skipping", "target_path", targetPath)
-	}
-	if readOnly {
-		if err := mounter.Mount(hostPath, targetPath, "", []string{"bind", "remount", "ro"}); err != nil {
-			slog.Error("bindMount: failed to remount read-only", "error", err, "host_path", hostPath, "target_path", targetPath)
-			return status.Errorf(codes.Internal, "bindMount: failed to remount read-only: %v", err)
+		if readOnly {
+			if err := remountReadOnlyBind(hostPath, targetPath); err != nil {
+				slog.Error("bindMount: failed to remount read-only", "error", err, "host_path", hostPath, "target_path", targetPath)
+				return status.Errorf(codes.Internal, "bindMount: failed to remount read-only: %v", err)
+			}
 		}
 	}
 

--- a/pkg/driver/publishers/bindmount.go
+++ b/pkg/driver/publishers/bindmount.go
@@ -20,30 +20,37 @@ var remountReadOnlyBind = func(hostPath, targetPath string) error {
 	return unix.Mount(hostPath, targetPath, "", unix.MS_BIND|unix.MS_REMOUNT|unix.MS_RDONLY, "")
 }
 
+type bindMountArgs struct {
+	hostPath   string
+	targetPath string
+	isFile     bool
+	readOnly   bool
+}
+
 // bindMount performs a bind mount from hostPath to targetPath.
 // It creates the target path if it doesn't exist (as file if isFile, directory otherwise).
 // Returns nil if already mounted or mount succeeds.
-func bindMount(afs afero.Afero, mounter mount.Interface, hostPath, targetPath string, isFile bool, readOnly bool) error {
-	slog.Info("bindMount: mounting", "host_path", hostPath, "target_path", targetPath, "read_only", readOnly)
+func bindMount(afs afero.Afero, mounter mount.Interface, args bindMountArgs) error {
+	slog.Info("bindMount: mounting", "host_path", args.hostPath, "target_path", args.targetPath, "read_only", args.readOnly)
 
 	// Verify source path exists before attempting mount
-	exists, err := afs.Exists(hostPath)
+	exists, err := afs.Exists(args.hostPath)
 	if err != nil {
 		return status.Errorf(codes.Internal, "bindMount: failed to check if source path exists: %v", err)
 	}
 	if !exists {
-		return status.Errorf(codes.FailedPrecondition, "bindMount: source path %q does not exist", hostPath)
+		return status.Errorf(codes.FailedPrecondition, "bindMount: source path %q does not exist", args.hostPath)
 	}
 
 	// Create target path if needed
-	if err := createHostPath(afs, targetPath, isFile); err != nil {
+	if err := createHostPath(afs, args.targetPath, args.isFile); err != nil {
 		return err
 	}
 
 	// Check if already mounted
 	// Note: IsLikelyNotMountPoint uses os.Stat internally, so we ignore "not exist" errors
 	// which can happen in tests with MemMapFs or when the target was just created
-	notMnt, err := mounter.IsLikelyNotMountPoint(targetPath)
+	notMnt, err := mounter.IsLikelyNotMountPoint(args.targetPath)
 	if err != nil && !os.IsNotExist(err) {
 		return status.Errorf(codes.Internal, "bindMount: failed to check mount point: %v", err)
 	}
@@ -51,24 +58,24 @@ func bindMount(afs afero.Afero, mounter mount.Interface, hostPath, targetPath st
 	// Perform bind mount if not already mounted
 	if notMnt {
 		options := []string{"bind"}
-		if readOnly {
+		if args.readOnly {
 			options = append(options, "ro")
 		}
-		if err := mounter.Mount(hostPath, targetPath, "", options); err != nil {
-			slog.Error("bindMount: failed to mount", "error", err, "host_path", hostPath, "target_path", targetPath)
+		if err := mounter.Mount(args.hostPath, args.targetPath, "", options); err != nil {
+			slog.Error("bindMount: failed to mount", "error", err, "host_path", args.hostPath, "target_path", args.targetPath)
 			return status.Errorf(codes.Internal, "bindMount: failed to mount: %v", err)
 		}
 	} else {
-		slog.Info("bindMount: already mounted, skipping", "target_path", targetPath)
-		if readOnly {
-			if err := remountReadOnlyBind(hostPath, targetPath); err != nil {
-				slog.Error("bindMount: failed to remount read-only", "error", err, "host_path", hostPath, "target_path", targetPath)
+		slog.Info("bindMount: already mounted, skipping", "target_path", args.targetPath)
+		if args.readOnly {
+			if err := remountReadOnlyBind(args.hostPath, args.targetPath); err != nil {
+				slog.Error("bindMount: failed to remount read-only", "error", err, "host_path", args.hostPath, "target_path", args.targetPath)
 				return status.Errorf(codes.Internal, "bindMount: failed to remount read-only: %v", err)
 			}
 		}
 	}
 
-	slog.Info("bindMount: successfully mounted", "host_path", hostPath, "target_path", targetPath, "read_only", readOnly)
+	slog.Info("bindMount: successfully mounted", "host_path", args.hostPath, "target_path", args.targetPath, "read_only", args.readOnly)
 	return nil
 }
 

--- a/pkg/driver/publishers/bindmount.go
+++ b/pkg/driver/publishers/bindmount.go
@@ -49,14 +49,14 @@ func bindMount(afs afero.Afero, mounter mount.Interface, hostPath, targetPath st
 			slog.Error("bindMount: failed to mount", "error", err, "host_path", hostPath, "target_path", targetPath)
 			return status.Errorf(codes.Internal, "bindMount: failed to mount: %v", err)
 		}
-		if readOnly {
-			if err := mounter.Mount(hostPath, targetPath, "", []string{"bind", "remount", "ro"}); err != nil {
-				slog.Error("bindMount: failed to remount read-only", "error", err, "host_path", hostPath, "target_path", targetPath)
-				return status.Errorf(codes.Internal, "bindMount: failed to remount read-only: %v", err)
-			}
-		}
 	} else {
 		slog.Info("bindMount: already mounted, skipping", "target_path", targetPath)
+	}
+	if readOnly {
+		if err := mounter.Mount(hostPath, targetPath, "", []string{"bind", "remount", "ro"}); err != nil {
+			slog.Error("bindMount: failed to remount read-only", "error", err, "host_path", hostPath, "target_path", targetPath)
+			return status.Errorf(codes.Internal, "bindMount: failed to remount read-only: %v", err)
+		}
 	}
 
 	slog.Info("bindMount: successfully mounted", "host_path", hostPath, "target_path", targetPath, "read_only", readOnly)

--- a/pkg/driver/publishers/bindmount.go
+++ b/pkg/driver/publishers/bindmount.go
@@ -18,8 +18,8 @@ import (
 // bindMount performs a bind mount from hostPath to targetPath.
 // It creates the target path if it doesn't exist (as file if isFile, directory otherwise).
 // Returns nil if already mounted or mount succeeds.
-func bindMount(afs afero.Afero, mounter mount.Interface, hostPath, targetPath string, isFile bool) error {
-	slog.Info("bindMount: mounting", "host_path", hostPath, "target_path", targetPath)
+func bindMount(afs afero.Afero, mounter mount.Interface, hostPath, targetPath string, isFile bool, readOnly bool) error {
+	slog.Info("bindMount: mounting", "host_path", hostPath, "target_path", targetPath, "read_only", readOnly)
 
 	// Verify source path exists before attempting mount
 	exists, err := afs.Exists(hostPath)
@@ -49,11 +49,17 @@ func bindMount(afs afero.Afero, mounter mount.Interface, hostPath, targetPath st
 			slog.Error("bindMount: failed to mount", "error", err, "host_path", hostPath, "target_path", targetPath)
 			return status.Errorf(codes.Internal, "bindMount: failed to mount: %v", err)
 		}
+		if readOnly {
+			if err := mounter.Mount(hostPath, targetPath, "", []string{"bind", "remount", "ro"}); err != nil {
+				slog.Error("bindMount: failed to remount read-only", "error", err, "host_path", hostPath, "target_path", targetPath)
+				return status.Errorf(codes.Internal, "bindMount: failed to remount read-only: %v", err)
+			}
+		}
 	} else {
 		slog.Info("bindMount: already mounted, skipping", "target_path", targetPath)
 	}
 
-	slog.Info("bindMount: successfully mounted", "host_path", hostPath, "target_path", targetPath)
+	slog.Info("bindMount: successfully mounted", "host_path", hostPath, "target_path", targetPath, "read_only", readOnly)
 	return nil
 }
 

--- a/pkg/driver/publishers/bindmount_test.go
+++ b/pkg/driver/publishers/bindmount_test.go
@@ -16,7 +16,8 @@ import (
 
 type recordingMounter struct {
 	*mount.FakeMounter
-	mounts []recordedMount
+	mounts       []recordedMount
+	alreadyMount bool
 }
 
 type recordedMount struct {
@@ -34,6 +35,13 @@ func (m *recordingMounter) Mount(source string, target string, fstype string, op
 		options: append([]string(nil), options...),
 	})
 	return m.FakeMounter.Mount(source, target, fstype, options)
+}
+
+func (m *recordingMounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	if m.alreadyMount {
+		return false, nil
+	}
+	return m.FakeMounter.IsLikelyNotMountPoint(file)
 }
 
 func TestBindMount_CreatesTargetDirectory(t *testing.T) {
@@ -110,4 +118,18 @@ func TestBindMount_ReadOnlyRemountsBind(t *testing.T) {
 	require.Len(t, mounter.mounts, 2)
 	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind"}}, mounter.mounts[0])
 	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind", "remount", "ro"}}, mounter.mounts[1])
+}
+
+func TestBindMount_ReadOnlyRemountsAlreadyMountedTarget(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	mounter := &recordingMounter{FakeMounter: mount.NewFakeMounter(nil), alreadyMount: true}
+
+	require.NoError(t, fs.MkdirAll("/host/path", 0755))
+	require.NoError(t, fs.MkdirAll("/target/path", 0755))
+
+	err := bindMount(fs, mounter, "/host/path", "/target/path", false, true)
+
+	require.NoError(t, err)
+	require.Len(t, mounter.mounts, 1)
+	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind", "remount", "ro"}}, mounter.mounts[0])
 }

--- a/pkg/driver/publishers/bindmount_test.go
+++ b/pkg/driver/publishers/bindmount_test.go
@@ -14,6 +14,28 @@ import (
 	"k8s.io/utils/mount"
 )
 
+type recordingMounter struct {
+	*mount.FakeMounter
+	mounts []recordedMount
+}
+
+type recordedMount struct {
+	source  string
+	target  string
+	fstype  string
+	options []string
+}
+
+func (m *recordingMounter) Mount(source string, target string, fstype string, options []string) error {
+	m.mounts = append(m.mounts, recordedMount{
+		source:  source,
+		target:  target,
+		fstype:  fstype,
+		options: append([]string(nil), options...),
+	})
+	return m.FakeMounter.Mount(source, target, fstype, options)
+}
+
 func TestBindMount_CreatesTargetDirectory(t *testing.T) {
 	fs := afero.Afero{Fs: afero.NewMemMapFs()}
 	mounter := mount.NewFakeMounter(nil)
@@ -21,7 +43,7 @@ func TestBindMount_CreatesTargetDirectory(t *testing.T) {
 	// Create source directory
 	require.NoError(t, fs.MkdirAll("/host/dir", 0755))
 
-	err := bindMount(fs, mounter, "/host/dir", "/target/dir", false)
+	err := bindMount(fs, mounter, "/host/dir", "/target/dir", false, false)
 
 	assert.NoError(t, err)
 	// Verify target directory was created in afero
@@ -45,7 +67,7 @@ func TestBindMount_CreatesTargetFile(t *testing.T) {
 	_, err := fs.Create("/host/socket.sock")
 	require.NoError(t, err)
 
-	err = bindMount(fs, mounter, "/host/socket.sock", "/target/socket.sock", true)
+	err = bindMount(fs, mounter, "/host/socket.sock", "/target/socket.sock", true, false)
 
 	assert.NoError(t, err)
 	// Verify target file was created in afero
@@ -65,7 +87,7 @@ func TestBindMount_CallsMounter(t *testing.T) {
 	// Create source directory
 	require.NoError(t, fs.MkdirAll("/host/path", 0755))
 
-	err := bindMount(fs, mounter, "/host/path", "/target/path", false)
+	err := bindMount(fs, mounter, "/host/path", "/target/path", false, false)
 
 	assert.NoError(t, err)
 	log := mounter.GetLog()
@@ -74,4 +96,18 @@ func TestBindMount_CallsMounter(t *testing.T) {
 	assert.Equal(t, "mount", log[0].Action)
 	assert.Equal(t, "/host/path", log[0].Source)
 	assert.Equal(t, "/target/path", log[0].Target)
+}
+
+func TestBindMount_ReadOnlyRemountsBind(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	mounter := &recordingMounter{FakeMounter: mount.NewFakeMounter(nil)}
+
+	require.NoError(t, fs.MkdirAll("/host/path", 0755))
+
+	err := bindMount(fs, mounter, "/host/path", "/target/path", false, true)
+
+	require.NoError(t, err)
+	require.Len(t, mounter.mounts, 2)
+	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind"}}, mounter.mounts[0])
+	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind", "remount", "ro"}}, mounter.mounts[1])
 }

--- a/pkg/driver/publishers/bindmount_test.go
+++ b/pkg/driver/publishers/bindmount_test.go
@@ -51,7 +51,12 @@ func TestBindMount_CreatesTargetDirectory(t *testing.T) {
 	// Create source directory
 	require.NoError(t, fs.MkdirAll("/host/dir", 0755))
 
-	err := bindMount(fs, mounter, "/host/dir", "/target/dir", false, false)
+	err := bindMount(fs, mounter, bindMountArgs{
+		hostPath:   "/host/dir",
+		targetPath: "/target/dir",
+		isFile:     false,
+		readOnly:   false,
+	})
 
 	assert.NoError(t, err)
 	// Verify target directory was created in afero
@@ -75,7 +80,12 @@ func TestBindMount_CreatesTargetFile(t *testing.T) {
 	_, err := fs.Create("/host/socket.sock")
 	require.NoError(t, err)
 
-	err = bindMount(fs, mounter, "/host/socket.sock", "/target/socket.sock", true, false)
+	err = bindMount(fs, mounter, bindMountArgs{
+		hostPath:   "/host/socket.sock",
+		targetPath: "/target/socket.sock",
+		isFile:     true,
+		readOnly:   false,
+	})
 
 	assert.NoError(t, err)
 	// Verify target file was created in afero
@@ -95,7 +105,12 @@ func TestBindMount_CallsMounter(t *testing.T) {
 	// Create source directory
 	require.NoError(t, fs.MkdirAll("/host/path", 0755))
 
-	err := bindMount(fs, mounter, "/host/path", "/target/path", false, false)
+	err := bindMount(fs, mounter, bindMountArgs{
+		hostPath:   "/host/path",
+		targetPath: "/target/path",
+		isFile:     false,
+		readOnly:   false,
+	})
 
 	assert.NoError(t, err)
 	log := mounter.GetLog()
@@ -112,7 +127,12 @@ func TestBindMount_ReadOnlyRemountsBind(t *testing.T) {
 
 	require.NoError(t, fs.MkdirAll("/host/path", 0755))
 
-	err := bindMount(fs, mounter, "/host/path", "/target/path", false, true)
+	err := bindMount(fs, mounter, bindMountArgs{
+		hostPath:   "/host/path",
+		targetPath: "/target/path",
+		isFile:     false,
+		readOnly:   true,
+	})
 
 	require.NoError(t, err)
 	require.Len(t, mounter.mounts, 1)
@@ -135,7 +155,12 @@ func TestBindMount_ReadOnlyRemountsAlreadyMountedTarget(t *testing.T) {
 	require.NoError(t, fs.MkdirAll("/host/path", 0755))
 	require.NoError(t, fs.MkdirAll("/target/path", 0755))
 
-	err := bindMount(fs, mounter, "/host/path", "/target/path", false, true)
+	err := bindMount(fs, mounter, bindMountArgs{
+		hostPath:   "/host/path",
+		targetPath: "/target/path",
+		isFile:     false,
+		readOnly:   true,
+	})
 
 	require.NoError(t, err)
 	assert.Empty(t, mounter.mounts)

--- a/pkg/driver/publishers/bindmount_test.go
+++ b/pkg/driver/publishers/bindmount_test.go
@@ -115,14 +115,22 @@ func TestBindMount_ReadOnlyRemountsBind(t *testing.T) {
 	err := bindMount(fs, mounter, "/host/path", "/target/path", false, true)
 
 	require.NoError(t, err)
-	require.Len(t, mounter.mounts, 2)
-	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind"}}, mounter.mounts[0])
-	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind", "remount", "ro"}}, mounter.mounts[1])
+	require.Len(t, mounter.mounts, 1)
+	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind", "ro"}}, mounter.mounts[0])
 }
 
 func TestBindMount_ReadOnlyRemountsAlreadyMountedTarget(t *testing.T) {
 	fs := afero.Afero{Fs: afero.NewMemMapFs()}
 	mounter := &recordingMounter{FakeMounter: mount.NewFakeMounter(nil), alreadyMount: true}
+	var remounted []recordedMount
+	originalRemountReadOnlyBind := remountReadOnlyBind
+	remountReadOnlyBind = func(hostPath, targetPath string) error {
+		remounted = append(remounted, recordedMount{source: hostPath, target: targetPath})
+		return nil
+	}
+	t.Cleanup(func() {
+		remountReadOnlyBind = originalRemountReadOnlyBind
+	})
 
 	require.NoError(t, fs.MkdirAll("/host/path", 0755))
 	require.NoError(t, fs.MkdirAll("/target/path", 0755))
@@ -130,6 +138,6 @@ func TestBindMount_ReadOnlyRemountsAlreadyMountedTarget(t *testing.T) {
 	err := bindMount(fs, mounter, "/host/path", "/target/path", false, true)
 
 	require.NoError(t, err)
-	require.Len(t, mounter.mounts, 1)
-	assert.Equal(t, recordedMount{source: "/host/path", target: "/target/path", options: []string{"bind", "remount", "ro"}}, mounter.mounts[0])
+	assert.Empty(t, mounter.mounts)
+	assert.Equal(t, []recordedMount{{source: "/host/path", target: "/target/path"}}, remounted)
 }

--- a/pkg/driver/publishers/injector_preload.go
+++ b/pkg/driver/publishers/injector_preload.go
@@ -73,7 +73,7 @@ func (p *injectorPreloadPublisher) Publish(req *csi.NodePublishVolumeRequest) (*
 	}
 
 	// Bind mount the file to the target path
-	if err := bindMount(p.fs, p.mounter, p.preloadFilePath, targetPath, true); err != nil {
+	if err := bindMount(p.fs, p.mounter, p.preloadFilePath, targetPath, true, true); err != nil {
 		return &PublisherResponse{VolumeType: DatadogInjectorPreload},
 			fmt.Errorf("failed to mount preload file: %w", err)
 	}

--- a/pkg/driver/publishers/injector_preload.go
+++ b/pkg/driver/publishers/injector_preload.go
@@ -73,7 +73,12 @@ func (p *injectorPreloadPublisher) Publish(req *csi.NodePublishVolumeRequest) (*
 	}
 
 	// Bind mount the file to the target path
-	if err := bindMount(p.fs, p.mounter, p.preloadFilePath, targetPath, true, true); err != nil {
+	if err := bindMount(p.fs, p.mounter, bindMountArgs{
+		hostPath:   p.preloadFilePath,
+		targetPath: targetPath,
+		isFile:     true,
+		readOnly:   true,
+	}); err != nil {
 		return &PublisherResponse{VolumeType: DatadogInjectorPreload},
 			fmt.Errorf("failed to mount preload file: %w", err)
 	}

--- a/pkg/driver/publishers/injector_preload_test.go
+++ b/pkg/driver/publishers/injector_preload_test.go
@@ -116,13 +116,10 @@ func TestInjectorPreloadPublisher_Publish_Success(t *testing.T) {
 
 	// Verify mount was called
 	log := mounter.GetLog()
-	require.Len(t, log, 2)
+	require.Len(t, log, 1)
 	assert.Equal(t, "mount", log[0].Action)
 	assert.Equal(t, "/var/datadog/ld.so.preload", log[0].Source)
 	assert.Equal(t, "/target/ld.so.preload", log[0].Target)
-	assert.Equal(t, "mount", log[1].Action)
-	assert.Equal(t, "/var/datadog/ld.so.preload", log[1].Source)
-	assert.Equal(t, "/target/ld.so.preload", log[1].Target)
 }
 
 func TestInjectorPreloadPublisher_Publish_Idempotent(t *testing.T) {
@@ -157,9 +154,9 @@ func TestInjectorPreloadPublisher_Publish_Idempotent(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, resp)
 
-	// Each read-only publish uses bind plus read-only remount.
+	// Each read-only publish uses a single read-only bind mount.
 	log := mounter.GetLog()
-	assert.Len(t, log, 4)
+	assert.Len(t, log, 2)
 }
 
 func TestInjectorPreloadPublisher_Publish_Concurrent(t *testing.T) {

--- a/pkg/driver/publishers/injector_preload_test.go
+++ b/pkg/driver/publishers/injector_preload_test.go
@@ -116,10 +116,13 @@ func TestInjectorPreloadPublisher_Publish_Success(t *testing.T) {
 
 	// Verify mount was called
 	log := mounter.GetLog()
-	require.Len(t, log, 1)
+	require.Len(t, log, 2)
 	assert.Equal(t, "mount", log[0].Action)
 	assert.Equal(t, "/var/datadog/ld.so.preload", log[0].Source)
 	assert.Equal(t, "/target/ld.so.preload", log[0].Target)
+	assert.Equal(t, "mount", log[1].Action)
+	assert.Equal(t, "/var/datadog/ld.so.preload", log[1].Source)
+	assert.Equal(t, "/target/ld.so.preload", log[1].Target)
 }
 
 func TestInjectorPreloadPublisher_Publish_Idempotent(t *testing.T) {
@@ -154,9 +157,9 @@ func TestInjectorPreloadPublisher_Publish_Idempotent(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, resp)
 
-	// Verify mount was called twice
+	// Each read-only publish uses bind plus read-only remount.
 	log := mounter.GetLog()
-	assert.Len(t, log, 2)
+	assert.Len(t, log, 4)
 }
 
 func TestInjectorPreloadPublisher_Publish_Concurrent(t *testing.T) {

--- a/pkg/driver/publishers/library.go
+++ b/pkg/driver/publishers/library.go
@@ -69,7 +69,7 @@ func (s libraryPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publisher
 		return &PublisherResponse{VolumeType: DatadogLibrary, VolumePath: image}, err
 	}
 
-	err = bindMount(s.fs, s.mounter, libraryPath, req.GetTargetPath(), false)
+	err = bindMount(s.fs, s.mounter, libraryPath, req.GetTargetPath(), false, true)
 	if err != nil {
 		return &PublisherResponse{VolumeType: DatadogLibrary, VolumePath: image}, err
 	}

--- a/pkg/driver/publishers/library.go
+++ b/pkg/driver/publishers/library.go
@@ -69,7 +69,12 @@ func (s libraryPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publisher
 		return &PublisherResponse{VolumeType: DatadogLibrary, VolumePath: image}, err
 	}
 
-	err = bindMount(s.fs, s.mounter, libraryPath, req.GetTargetPath(), false, true)
+	err = bindMount(s.fs, s.mounter, bindMountArgs{
+		hostPath:   libraryPath,
+		targetPath: req.GetTargetPath(),
+		isFile:     false,
+		readOnly:   true,
+	})
 	if err != nil {
 		return &PublisherResponse{VolumeType: DatadogLibrary, VolumePath: image}, err
 	}

--- a/pkg/driver/publishers/library_test.go
+++ b/pkg/driver/publishers/library_test.go
@@ -201,11 +201,15 @@ func TestLibraryPublisher_Publish_Success(t *testing.T) {
 
 	// Verify mount was called
 	mountLog := mounter.GetLog()
-	require.Len(t, mountLog, 1)
+	require.Len(t, mountLog, 2)
 	assert.Equal(t, "mount", mountLog[0].Action)
 	assert.Equal(t, targetPath, mountLog[0].Target)
 	assert.True(t, strings.Contains(mountLog[0].Source, "datadog-init/package"),
 		"mount source should contain library path, got: %s", mountLog[0].Source)
+	assert.Equal(t, "mount", mountLog[1].Action)
+	assert.Equal(t, targetPath, mountLog[1].Target)
+	assert.True(t, strings.Contains(mountLog[1].Source, "datadog-init/package"),
+		"remount source should contain library path, got: %s", mountLog[1].Source)
 }
 
 func TestRegistryAllowed(t *testing.T) {

--- a/pkg/driver/publishers/library_test.go
+++ b/pkg/driver/publishers/library_test.go
@@ -201,15 +201,11 @@ func TestLibraryPublisher_Publish_Success(t *testing.T) {
 
 	// Verify mount was called
 	mountLog := mounter.GetLog()
-	require.Len(t, mountLog, 2)
+	require.Len(t, mountLog, 1)
 	assert.Equal(t, "mount", mountLog[0].Action)
 	assert.Equal(t, targetPath, mountLog[0].Target)
 	assert.True(t, strings.Contains(mountLog[0].Source, "datadog-init/package"),
 		"mount source should contain library path, got: %s", mountLog[0].Source)
-	assert.Equal(t, "mount", mountLog[1].Action)
-	assert.Equal(t, targetPath, mountLog[1].Target)
-	assert.True(t, strings.Contains(mountLog[1].Source, "datadog-init/package"),
-		"remount source should contain library path, got: %s", mountLog[1].Source)
 }
 
 func TestRegistryAllowed(t *testing.T) {

--- a/pkg/driver/publishers/local.go
+++ b/pkg/driver/publishers/local.go
@@ -46,7 +46,12 @@ func (s localPublisher) Publish(req *csi.NodePublishVolumeRequest) (*PublisherRe
 	resp := &PublisherResponse{VolumeType: volumeType, VolumePath: hostPath}
 	targetPath := req.GetTargetPath()
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, false, false)
+	return resp, bindMount(s.fs, s.mounter, bindMountArgs{
+		hostPath:   hostPath,
+		targetPath: targetPath,
+		isFile:     false,
+		readOnly:   false,
+	})
 }
 
 func (s localPublisher) Unpublish(*csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {

--- a/pkg/driver/publishers/local.go
+++ b/pkg/driver/publishers/local.go
@@ -46,7 +46,7 @@ func (s localPublisher) Publish(req *csi.NodePublishVolumeRequest) (*PublisherRe
 	resp := &PublisherResponse{VolumeType: volumeType, VolumePath: hostPath}
 	targetPath := req.GetTargetPath()
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, false)
+	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, false, false)
 }
 
 func (s localPublisher) Unpublish(*csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {

--- a/pkg/driver/publishers/local_legacy.go
+++ b/pkg/driver/publishers/local_legacy.go
@@ -55,7 +55,7 @@ func (s localLegacyPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publi
 		return resp, fmt.Errorf("path %q is not allowed; permitted paths are %v", hostPath, allowedPaths)
 	}
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, false)
+	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, false, false)
 }
 
 func (s localLegacyPublisher) Unpublish(*csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {

--- a/pkg/driver/publishers/local_legacy.go
+++ b/pkg/driver/publishers/local_legacy.go
@@ -55,7 +55,12 @@ func (s localLegacyPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publi
 		return resp, fmt.Errorf("path %q is not allowed; permitted paths are %v", hostPath, allowedPaths)
 	}
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, false, false)
+	return resp, bindMount(s.fs, s.mounter, bindMountArgs{
+		hostPath:   hostPath,
+		targetPath: targetPath,
+		isFile:     false,
+		readOnly:   false,
+	})
 }
 
 func (s localLegacyPublisher) Unpublish(*csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {

--- a/pkg/driver/publishers/socket.go
+++ b/pkg/driver/publishers/socket.go
@@ -50,7 +50,12 @@ func (s socketPublisher) Publish(req *csi.NodePublishVolumeRequest) (*PublisherR
 		return resp, fmt.Errorf("socket not found at %q", hostPath)
 	}
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, true, false)
+	return resp, bindMount(s.fs, s.mounter, bindMountArgs{
+		hostPath:   hostPath,
+		targetPath: targetPath,
+		isFile:     true,
+		readOnly:   false,
+	})
 }
 
 func (s socketPublisher) Unpublish(req *csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {

--- a/pkg/driver/publishers/socket.go
+++ b/pkg/driver/publishers/socket.go
@@ -50,7 +50,7 @@ func (s socketPublisher) Publish(req *csi.NodePublishVolumeRequest) (*PublisherR
 		return resp, fmt.Errorf("socket not found at %q", hostPath)
 	}
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, true)
+	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, true, false)
 }
 
 func (s socketPublisher) Unpublish(req *csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {

--- a/pkg/driver/publishers/socket_legacy.go
+++ b/pkg/driver/publishers/socket_legacy.go
@@ -63,7 +63,7 @@ func (s socketLegacyPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publ
 		return resp, fmt.Errorf("socket not found at %q", hostPath)
 	}
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, true)
+	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, true, false)
 }
 
 func (s socketLegacyPublisher) Unpublish(*csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {

--- a/pkg/driver/publishers/socket_legacy.go
+++ b/pkg/driver/publishers/socket_legacy.go
@@ -63,7 +63,12 @@ func (s socketLegacyPublisher) Publish(req *csi.NodePublishVolumeRequest) (*Publ
 		return resp, fmt.Errorf("socket not found at %q", hostPath)
 	}
 
-	return resp, bindMount(s.fs, s.mounter, hostPath, targetPath, true, false)
+	return resp, bindMount(s.fs, s.mounter, bindMountArgs{
+		hostPath:   hostPath,
+		targetPath: targetPath,
+		isFile:     true,
+		readOnly:   false,
+	})
 }
 
 func (s socketLegacyPublisher) Unpublish(*csi.NodeUnpublishVolumeRequest) (*PublisherResponse, error) {


### PR DESCRIPTION
## Description

Remounts DatadogLibrary and DatadogInjectorPreload bind mounts as read-only after the initial bind mount.

This hardens the default non-privileged workload path. Privileged workloads can still have broader mount capabilities and should be treated separately.

## Related Issue

https://datadoghq.atlassian.net/browse/INPLAT-1177

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [x] Documentation updated if needed
- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- `go test ./pkg/driver/publishers -count=1`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...`