### PR TITLE
release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-21
+
 ### Security
 
 - Upgraded `google.golang.org/grpc` from v1.70.0 to v1.79.3 to remediate CVE-2026-33186 (authorization bypass via missing leading slash in `:path`).
+- Upgraded `golang.org/x/net` from v0.48.0 to v0.57.0 and `golang.org/x/sys` from v0.39.0 to v0.47.0 to remediate multiple CVEs, notably CVE-2026-39821 (Punycode label handling in `golang.org/x/net/idna`) and CVE-2026-33814 (HTTP/2 transport denial of service).
 
 ## [1.3.0] - 2026-07-01
 
@@ -116,7 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prometheus metrics endpoint for basic telemetry
 - Multi-architecture Docker image support (linux/amd64, linux/arm64)
 
-[Unreleased]: https://github.com/DataDog/datadog-csi-driver/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/DataDog/datadog-csi-driver/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/DataDog/datadog-csi-driver/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/DataDog/datadog-csi-driver/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/DataDog/datadog-csi-driver/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/DataDog/datadog-csi-driver/compare/v1.2.0...v1.2.1


### PR DESCRIPTION
### What does this PR do?

Cuts the **v1.3.1** release — folds the security dependency fixes now on `main` into a versioned changelog section (`[1.3.1]`) and updates the compare links. No code changes.

Ships:
- `google.golang.org/grpc` v1.70.0 → v1.79.3 — CVE-2026-33186 (gRPC-Go authorization bypass via missing leading slash in `:path`). Fixes VULN-88234 (Critical). Merged in #99.
- `golang.org/x/net` v0.48.0 → v0.57.0 and `golang.org/x/sys` v0.39.0 → v0.47.0 — multiple CVEs, notably CVE-2026-39821 (critical) and CVE-2026-33814 (high). Merged in #101.

Once merged, tagged `v1.3.1`, and published, the openvex scanner can clear the associated VULN tickets.

### Describe your test plan

Changelog-only release commit; no code paths touched. #99 and #101 both merged green (unit + e2e amd64/arm64). Relying on CI staying green here.

Post-merge: tag `v1.3.1` on the release commit, push it, then trigger the GitLab publish jobs to push images to the registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
