### PR TITLE
feat(csi): authenticate private registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added driver-scoped private registry authentication for `DatadogLibrary` volumes using Kubernetes image pull Secrets.
+
 ## [1.3.1] - 2026-07-21
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ test:
 	go test -v -count=1 ./...
 
 e2e: install-kind
-	./test/e2e/setup-env.sh
-	kubectl apply -f test/e2e/manifests -n default
-	go test -v -count=1 -tags=e2e ./test/e2e
-	./test/e2e/clean-env.sh
+	@trap './test/e2e/clean-env.sh' EXIT; \
+		./test/e2e/setup-env.sh && \
+		kubectl apply -f test/e2e/manifests -n default && \
+		go test -v -count=1 -tags=e2e ./test/e2e
 
 .PHONY: build
 .PHONY: docker-buildx-ci

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/cli v28.2.2+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
@@ -96,6 +95,7 @@ require (
 )
 
 require (
+	github.com/docker/cli v28.2.2+incompatible
 	github.com/google/go-containerregistry v0.20.6
 	github.com/mholt/archives v0.1.5
 	github.com/prometheus/client_model v0.6.1

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Datadog/datadog-csi-driver/pkg/driver/publishers"
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
 	"github.com/Datadog/datadog-csi-driver/pkg/metrics"
+	"github.com/Datadog/datadog-csi-driver/pkg/registryauth"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/spf13/afero"
@@ -89,9 +90,18 @@ func newDatadogCSIDriver(
 
 	var lm *librarymanager.LibraryManager
 	if storageBasePath != "" {
+		downloader := librarymanager.NewDownloader()
+		keychain, err := registryauth.NewKeychainFromEnvironment()
+		if err != nil {
+			return nil, fmt.Errorf("could not configure registry authentication: %w", err)
+		}
+		if keychain != nil {
+			downloader = librarymanager.NewDownloaderWithKeychain(keychain)
+		}
 		lm, err = librarymanager.NewLibraryManager(
 			storageBasePath,
 			librarymanager.WithFilesystem(fs),
+			librarymanager.WithDownloader(downloader),
 			librarymanager.WithCleanupStrategy(librarymanager.NewDelayedCleanupStrategy(cleanupDelay)),
 			librarymanager.WithEventListener(metrics.NewLibraryListener()),
 		)

--- a/pkg/librarymanager/downloader.go
+++ b/pkg/librarymanager/downloader.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
@@ -25,17 +26,31 @@ const (
 // Downloader enables downloading and extracting directories from container images.
 type Downloader struct {
 	roundTripper http.RoundTripper
+	keychain     authn.Keychain
 }
 
 // NewDownloader creates a new downloader with the default settings.
 func NewDownloader() *Downloader {
-	return NewDownloaderWithRoundTripper(http.DefaultTransport)
+	return newDownloader(http.DefaultTransport, nil)
+}
+
+// NewDownloaderWithKeychain creates a downloader with driver-scoped registry credentials.
+func NewDownloaderWithKeychain(keychain authn.Keychain) *Downloader {
+	return newDownloader(http.DefaultTransport, keychain)
 }
 
 // NewDownloaderWithRoundTripper creates a new downloader with the provided round tripper.
 func NewDownloaderWithRoundTripper(roundTripper http.RoundTripper) *Downloader {
+	return newDownloader(roundTripper, nil)
+}
+
+func newDownloader(roundTripper http.RoundTripper, keychain authn.Keychain) *Downloader {
+	if keychain == nil {
+		keychain = authn.NewMultiKeychain()
+	}
 	return &Downloader{
 		roundTripper: roundTripper,
+		keychain:     keychain,
 	}
 }
 
@@ -44,6 +59,7 @@ func NewDownloaderWithRoundTripper(roundTripper http.RoundTripper) *Downloader {
 func (d *Downloader) Download(ctx context.Context, image string, dst string) (int64, error) {
 	img, err := crane.Pull(image,
 		crane.WithContext(ctx),
+		crane.WithAuthFromKeychain(d.keychain),
 		crane.WithUserAgent(userAgent),
 		crane.WithTransport(d.roundTripper),
 		crane.WithPlatform(&v1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}),
@@ -74,6 +90,7 @@ func (d *Downloader) Download(ctx context.Context, image string, dst string) (in
 func (d *Downloader) FetchDigest(ctx context.Context, image string) (string, error) {
 	digest, err := crane.Digest(image,
 		crane.WithContext(ctx),
+		crane.WithAuthFromKeychain(d.keychain),
 		crane.WithUserAgent(userAgent),
 		crane.WithTransport(d.roundTripper),
 		crane.WithPlatform(&v1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}),

--- a/pkg/librarymanager/downloader_test.go
+++ b/pkg/librarymanager/downloader_test.go
@@ -7,11 +7,13 @@ package librarymanager_test
 
 import (
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/Datadog/datadog-csi-driver/pkg/librarymanager"
+	"github.com/Datadog/datadog-csi-driver/pkg/registryauth"
 	"github.com/Datadog/datadog-csi-driver/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -64,4 +66,31 @@ func TestDownload(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDownloadWithDriverScopedAuthentication(t *testing.T) {
+	const (
+		username = "alice"
+		password = "password"
+	)
+	localRegistry := testutil.NewAuthenticatedLocalRegistry(t, username, password)
+	defer localRegistry.Stop()
+	image := localRegistry.AddImage(t, "testdata/image.tar", "private/test", "latest")
+
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	config := `{"auths":{"` + localRegistry.Registry(t) + `":{"auth":"` + auth + `"}}}`
+	t.Setenv("DD_APM_REGISTRY_AUTH_0", config)
+	keychain, err := registryauth.NewKeychainFromEnvironment()
+	require.NoError(t, err)
+
+	downloader := librarymanager.NewDownloaderWithKeychain(keychain)
+	ctx := context.Background()
+	digest, err := downloader.FetchDigest(ctx, image)
+	require.NoError(t, err)
+	require.NotEmpty(t, digest)
+
+	scratch := testutil.NewTempScratchDirectory(t)
+	defer scratch.Cleanup(t)
+	_, err = downloader.Download(ctx, image, scratch.Path(t))
+	require.NoError(t, err)
 }

--- a/pkg/registryauth/registryauth.go
+++ b/pkg/registryauth/registryauth.go
@@ -1,0 +1,70 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package registryauth
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docker/cli/cli/config/configfile"
+	dockertypes "github.com/docker/cli/cli/config/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+const envPrefix = "DD_APM_REGISTRY_AUTH_"
+
+// NewKeychainFromEnvironment creates a keychain from all indexed registry
+// authentication environment variables.
+func NewKeychainFromEnvironment() (authn.Keychain, error) {
+	config := configfile.New("")
+	hasCredentials := false
+	for _, env := range os.Environ() {
+		name, value, ok := strings.Cut(env, "=")
+		if ok && strings.HasPrefix(name, envPrefix) {
+			if err := config.LoadFromReader(strings.NewReader(value)); err != nil {
+				return nil, fmt.Errorf("invalid registry credentials: %w", err)
+			}
+			hasCredentials = true
+		}
+	}
+	if !hasCredentials {
+		return nil, nil
+	}
+	return &keychain{config: config}, nil
+}
+
+type keychain struct {
+	config *configfile.ConfigFile
+}
+
+func (k *keychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	var config, empty dockertypes.AuthConfig
+	for _, key := range []string{target.String(), target.RegistryStr()} {
+		if key == name.DefaultRegistry {
+			key = authn.DefaultAuthKey
+		}
+		var err error
+		config, err = k.config.GetAuthConfig(key)
+		if err != nil {
+			return nil, err
+		}
+		config.ServerAddress = ""
+		if config != empty {
+			break
+		}
+	}
+	if config == empty {
+		return authn.Anonymous, nil
+	}
+	return authn.FromConfig(authn.AuthConfig{
+		Username:      config.Username,
+		Password:      config.Password,
+		IdentityToken: config.IdentityToken,
+		RegistryToken: config.RegistryToken,
+	}), nil
+}

--- a/pkg/registryauth/registryauth_test.go
+++ b/pkg/registryauth/registryauth_test.go
@@ -1,0 +1,40 @@
+// Datadog datadog-csi driver
+// Copyright 2025-present Datadog, Inc.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+
+package registryauth
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeychainMergesEnvironmentCredentials(t *testing.T) {
+	t.Setenv(envPrefix+"0", `{"auths":{"first.example.com":{"username":"alice","password":"first"}}}`)
+	t.Setenv(envPrefix+"1", `{"auths":{"https://second.example.com/v1/":{"username":"bob","password":"second"}}}`)
+
+	keychain, err := NewKeychainFromEnvironment()
+	require.NoError(t, err)
+	for repository, expectedUser := range map[string]string{
+		"first.example.com/datadog/library":  "alice",
+		"second.example.com/datadog/library": "bob",
+	} {
+		target, err := name.NewRepository(repository)
+		require.NoError(t, err)
+		authenticator, err := keychain.Resolve(target)
+		require.NoError(t, err)
+		config, err := authenticator.Authorization()
+		require.NoError(t, err)
+		require.Equal(t, expectedUser, config.Username)
+	}
+}
+
+func TestKeychainRejectsInvalidEnvironmentCredentials(t *testing.T) {
+	t.Setenv(envPrefix+"0", `invalid`)
+
+	_, err := NewKeychainFromEnvironment()
+	require.Error(t, err)
+}

--- a/pkg/testutil/registry.go
+++ b/pkg/testutil/registry.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	imageref "github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -26,16 +27,39 @@ import (
 type LocalRegistry struct {
 	srv      *httptest.Server
 	registry string
+	username string
+	password string
 }
 
 // NewLocalRegistry creates a new local OCI registry for testing.
 func NewLocalRegistry(t *testing.T) *LocalRegistry {
 	t.Helper()
-	srv := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", log.LstdFlags))))
-	return &LocalRegistry{
-		srv:      srv,
-		registry: strings.TrimPrefix(srv.URL, "http://"),
-	}
+	return newLocalRegistry(t, "", "")
+}
+
+// NewAuthenticatedLocalRegistry creates a local OCI registry protected by Basic Auth.
+func NewAuthenticatedLocalRegistry(t *testing.T, username, password string) *LocalRegistry {
+	t.Helper()
+	return newLocalRegistry(t, username, password)
+}
+
+func newLocalRegistry(t *testing.T, username, password string) *LocalRegistry {
+	t.Helper()
+	r := &LocalRegistry{username: username, password: password}
+	registryHandler := registry.New(registry.Logger(log.New(io.Discard, "", log.LstdFlags)))
+	r.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if username != "" {
+			gotUsername, gotPassword, ok := req.BasicAuth()
+			if !ok || gotUsername != username || gotPassword != password {
+				w.Header().Set("WWW-Authenticate", `Basic realm="registry"`)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		registryHandler.ServeHTTP(w, req)
+	}))
+	r.registry = strings.TrimPrefix(r.srv.URL, "http://")
+	return r
 }
 
 // Stop stops the test registry server.
@@ -68,7 +92,14 @@ func (r *LocalRegistry) AddImage(t *testing.T, tarPath, name, version string) st
 	img, err := tarball.ImageFromPath(tarPath, nil)
 	require.NoError(t, err, "could not load tarball image")
 
-	err = crane.Push(img, ref.String(), crane.WithTransport(r.srv.Client().Transport))
+	options := []crane.Option{crane.WithTransport(r.srv.Client().Transport)}
+	if r.username != "" {
+		options = append(options, crane.WithAuth(authn.FromConfig(authn.AuthConfig{
+			Username: r.username,
+			Password: r.password,
+		})))
+	}
+	err = crane.Push(img, ref.String(), options...)
 	require.NoError(t, err, "could not push image to test registry")
 
 	return image

--- a/test/e2e/clean-env.sh
+++ b/test/e2e/clean-env.sh
@@ -1,3 +1,15 @@
-CLUSTER_NAME="csi-e2e"
+#!/bin/bash
+set -euo pipefail
 
-echo "Cleaning up the Kind cluster..."; kind delete cluster --name $CLUSTER_NAME
+CLUSTER_NAME="csi-e2e"
+REGISTRY_NAME="csi-e2e-registry"
+AUTH_VOLUME="csi-e2e-registry-auth"
+CRANE_AUTH_VOLUME="csi-e2e-crane-auth"
+
+echo "Cleaning up the private registry..."
+docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1 || true
+docker volume rm "$AUTH_VOLUME" >/dev/null 2>&1 || true
+docker volume rm "$CRANE_AUTH_VOLUME" >/dev/null 2>&1 || true
+
+echo "Cleaning up the Kind cluster..."
+kind delete cluster --name "$CLUSTER_NAME"

--- a/test/e2e/library_e2e_test.go
+++ b/test/e2e/library_e2e_test.go
@@ -19,6 +19,7 @@ func TestLibraryPublisher(t *testing.T) {
 		{"consumer-library", "Library test passed"},
 		{"consumer-library-digest", "Library digest test passed"},
 		{"consumer-library-tag-digest", "Library tag+digest test passed"},
+		{"consumer-library-private", "Private library authentication test passed"},
 	}
 
 	// Extract pod names for waitForPodsRunning

--- a/test/e2e/setup-env.sh
+++ b/test/e2e/setup-env.sh
@@ -6,28 +6,90 @@ HELM_RELEASE="datadog-csi"
 NAMESPACE="datadog"
 IMAGE_NAME="datadog-csi-driver:dev"
 PLATFORM="linux/$(uname -m)"
+REGISTRY_NAME="csi-e2e-registry"
+REGISTRY_IMAGE="registry:2.8.3"
+REGISTRY_USER="csi-e2e"
+REGISTRY_PASSWORD="csi-e2e-password"
+AUTH_VOLUME="csi-e2e-registry-auth"
+CRANE_AUTH_VOLUME="csi-e2e-crane-auth"
+CRANE_IMAGE="gcr.io/go-containerregistry/crane:v0.20.3"
+PUBLIC_LIBRARY="gcr.io/datadoghq/apm-inject:0.55.0"
 
 # Check if the cluster already exists and delete it
-echo "🧱 [1/5] Checking if Kind cluster already exists..."
+echo "🧱 [1/7] Checking if Kind cluster already exists..."
+docker rm -f "$REGISTRY_NAME" >/dev/null 2>&1 || true
+docker volume rm "$AUTH_VOLUME" >/dev/null 2>&1 || true
+docker volume rm "$CRANE_AUTH_VOLUME" >/dev/null 2>&1 || true
 if kind get clusters | grep -q "$CLUSTER_NAME"; then
   echo "Cluster $CLUSTER_NAME exists. Deleting it..."
   kind delete cluster --name "$CLUSTER_NAME"
 fi
 
 # Create the Kind cluster
-echo "🧱 [2/5] Creating Kind cluster..."
+echo "🧱 [2/7] Creating Kind cluster..."
 kind create cluster --name "$CLUSTER_NAME" --wait 60s
 
 # Build the Docker image
-echo "🐳 [3/5] Building CSI driver Docker image..."
+echo "🐳 [3/7] Building CSI driver Docker image..."
 PLATFORM="$PLATFORM" DOCKER_IMAGE="$IMAGE_NAME" make build
 
 # Load the image into the Kind cluster
-echo "📦 [4/5] Loading image into kind..."
+echo "📦 [4/7] Loading image into kind..."
 kind load docker-image "$IMAGE_NAME" --name "$CLUSTER_NAME"
 
+# Start a Basic Auth registry on the Kind Docker network
+echo "🔐 [5/7] Starting authenticated OCI registry..."
+docker volume create "$AUTH_VOLUME" >/dev/null
+docker run --rm \
+  --mount "source=$AUTH_VOLUME,target=/auth" \
+  httpd:2.4-alpine \
+  sh -c 'htpasswd -Bbn "$1" "$2" > /auth/htpasswd' -- \
+  "$REGISTRY_USER" "$REGISTRY_PASSWORD"
+docker run -d \
+  --name "$REGISTRY_NAME" \
+  --network kind \
+  --mount "source=$AUTH_VOLUME,target=/auth,readonly" \
+  -e REGISTRY_AUTH=htpasswd \
+  -e REGISTRY_AUTH_HTPASSWD_REALM="CSI E2E Registry" \
+  -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+  "$REGISTRY_IMAGE" >/dev/null
+
+REGISTRY_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$REGISTRY_NAME")"
+REGISTRY_ADDRESS="${REGISTRY_IP}:5000"
+PRIVATE_LIBRARY="${REGISTRY_ADDRESS}/datadog/apm-inject:0.55.0"
+
+docker volume create "$CRANE_AUTH_VOLUME" >/dev/null
+registry_ready=false
+for _ in {1..30}; do
+  if docker run --rm --network kind \
+    --user 0:0 \
+    --mount "source=$CRANE_AUTH_VOLUME,target=/config" \
+    -e DOCKER_CONFIG=/config \
+    "$CRANE_IMAGE" auth login "$REGISTRY_ADDRESS" \
+    --username "$REGISTRY_USER" \
+    --password "$REGISTRY_PASSWORD" \
+    --insecure >/dev/null 2>&1; then
+    registry_ready=true
+    break
+  fi
+  sleep 1
+done
+if [ "$registry_ready" != true ]; then
+  echo "Authenticated registry did not become ready"
+  exit 1
+fi
+if docker run --rm --network kind "$CRANE_IMAGE" catalog "$REGISTRY_ADDRESS" --insecure >/dev/null 2>&1; then
+  echo "Registry unexpectedly allows anonymous access"
+  exit 1
+fi
+docker run --rm --network kind \
+  --user 0:0 \
+  --mount "source=$CRANE_AUTH_VOLUME,target=/config,readonly" \
+  -e DOCKER_CONFIG=/config \
+  "$CRANE_IMAGE" copy "$PUBLIC_LIBRARY" "$PRIVATE_LIBRARY" --insecure
+
 # Install the Helm chart with the local image
-echo "🚀 [5/5] Installing Helm chart with custom image..."
+echo "🚀 [6/7] Installing Helm chart with custom image..."
 helm repo add datadog https://helm.datadoghq.com || true
 helm repo update
 
@@ -45,4 +107,37 @@ helm upgrade --install "$HELM_RELEASE" datadog/datadog-csi-driver \
   --set sockets.apmHostSocketPath="/socket-dir/apm.sock" \
   --set sockets.dsdHostSocketPath="/socket-dir/dsd.sock"
 
-echo "✅ CSI driver deployed using local image."
+# Inject the private registry credentials into the published chart used by E2E.
+echo "🧪 [7/7] Configuring the private registry test..."
+AUTH="$(printf '%s:%s' "$REGISTRY_USER" "$REGISTRY_PASSWORD" | base64 | tr -d '\n')"
+DOCKER_CONFIG_JSON="$(printf '{"auths":{"%s":{"auth":"%s"}}}' "$REGISTRY_ADDRESS" "$AUTH")"
+kubectl create secret generic private-library-registry \
+  --namespace "$NAMESPACE" \
+  --type kubernetes.io/dockerconfigjson \
+  --from-literal=.dockerconfigjson="$DOCKER_CONFIG_JSON"
+kubectl patch daemonset datadog-csi-driver-node-server \
+  --namespace "$NAMESPACE" \
+  --type strategic \
+  --patch "$(cat <<'EOF'
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-node-driver
+          env:
+            - name: DD_APM_REGISTRY_AUTH_0
+              valueFrom:
+                secretKeyRef:
+                  name: private-library-registry
+                  key: .dockerconfigjson
+EOF
+)"
+kubectl rollout status daemonset/datadog-csi-driver-node-server \
+  --namespace "$NAMESPACE" \
+  --timeout=120s
+
+sed "s|PRIVATE_REGISTRY_ADDRESS|$REGISTRY_ADDRESS|g" \
+  "$SCRIPT_DIR/templates/consumer-library-private.yaml" |
+  kubectl apply -f -
+
+echo "✅ CSI driver and authenticated registry deployed."

--- a/test/e2e/templates/consumer-library-private.yaml
+++ b/test/e2e/templates/consumer-library-private.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: consumer-library-private
+  namespace: default
+spec:
+  containers:
+    - name: consumer-library-private
+      image: busybox
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set -e
+          trap 'rc=$?; [ $rc -ne 0 ] && echo "TEST FAILED (exit code: $rc)"; sleep 3600' EXIT
+          test -f /test-library/0.55.0/inject/launcher.preload.so
+          echo "Private library authentication test passed"
+      volumeMounts:
+        - name: dd-library-volume
+          mountPath: /test-library
+          readOnly: true
+  volumes:
+    - name: dd-library-volume
+      csi:
+        driver: k8s.csi.datadoghq.com
+        readOnly: true
+        volumeAttributes:
+          type: DatadogLibrary
+          dd.csi.datadog.com/library.package: apm-inject
+          dd.csi.datadog.com/library.registry: PRIVATE_REGISTRY_ADDRESS/datadog
+          dd.csi.datadog.com/library.version: "0.55.0"


### PR DESCRIPTION
## Description

Allow the CSI driver to resolve and download `DatadogLibrary` images from private registries. Docker pull credentials are supplied through indexed environment variables populated from Kubernetes image pull Secrets and merged into a standard Docker keychain.

## Related Issue

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [x] Documentation updated if needed
- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- `go test ./...`
- `make e2e`
- The E2E suite starts a Basic Auth OCI registry, rejects anonymous access, and mounts a private `DatadogLibrary` through CSI.

## Additional Notes

Companion Helm chart PR: https://github.com/DataDog/helm-charts/pull/2834